### PR TITLE
Don't send redundant emails

### DIFF
--- a/netbout-web/src/main/java/com/netbout/email/EmAlias.java
+++ b/netbout-web/src/main/java/com/netbout/email/EmAlias.java
@@ -28,9 +28,7 @@ package com.netbout.email;
 
 import com.jcabi.aspects.Immutable;
 import com.jcabi.aspects.Loggable;
-import com.jcabi.email.Envelope;
 import com.jcabi.email.Postman;
-import com.jcabi.email.stamp.StSender;
 import com.netbout.spi.Alias;
 import com.netbout.spi.Inbox;
 import java.io.IOException;
@@ -69,16 +67,7 @@ final class EmAlias implements Alias {
      */
     EmAlias(final Alias org, final Postman pst) {
         this.origin = org;
-        this.postman = new Postman() {
-            @Override
-            public void send(final Envelope envelope) throws IOException {
-                pst.send(
-                    new Envelope.MIME(envelope).with(
-                        new StSender(org.name(), "no-reply@netbout.com")
-                    )
-                );
-            }
-        };
+        this.postman = pst;
     }
 
     @Override

--- a/netbout-web/src/main/java/com/netbout/email/EmAlias.java
+++ b/netbout-web/src/main/java/com/netbout/email/EmAlias.java
@@ -113,6 +113,6 @@ final class EmAlias implements Alias {
 
     @Override
     public Inbox inbox() throws IOException {
-        return new EmInbox(this.origin.inbox(), this.postman);
+        return new EmInbox(this.origin.inbox(), this.name(), this.postman);
     }
 }

--- a/netbout-web/src/main/java/com/netbout/email/EmBout.java
+++ b/netbout-web/src/main/java/com/netbout/email/EmBout.java
@@ -57,6 +57,11 @@ final class EmBout implements Bout {
     private final transient Bout origin;
 
     /**
+     * Alias of myself.
+     */
+    private final transient String self;
+
+    /**
      * Postman.
      */
     private final transient Postman postman;
@@ -64,10 +69,12 @@ final class EmBout implements Bout {
     /**
      * Public ctor.
      * @param org Origin
+     * @param slf Self alias
      * @param pst Postman
      */
-    EmBout(final Bout org, final Postman pst) {
+    EmBout(final Bout org, final String slf, final Postman pst) {
         this.origin = org;
+        this.self = slf;
         this.postman = pst;
     }
 
@@ -100,6 +107,7 @@ final class EmBout implements Bout {
     public Messages messages() throws IOException {
         return new EmMessages(
             this.origin.messages(),
+            this.self,
             this.postman,
             this
         );

--- a/netbout-web/src/main/java/com/netbout/email/EmInbox.java
+++ b/netbout-web/src/main/java/com/netbout/email/EmInbox.java
@@ -57,6 +57,11 @@ final class EmInbox implements Inbox {
     private final transient Inbox origin;
 
     /**
+     * Alias of myself.
+     */
+    private final transient String self;
+
+    /**
      * Postman.
      */
     private final transient Postman postman;
@@ -64,10 +69,12 @@ final class EmInbox implements Inbox {
     /**
      * Public ctor.
      * @param org Origin
+     * @param slf Self alias
      * @param pst Postman
      */
-    EmInbox(final Inbox org, final Postman pst) {
+    EmInbox(final Inbox org, final String slf, final Postman pst) {
         this.origin = org;
+        this.self = slf;
         this.postman = pst;
     }
 
@@ -87,12 +94,16 @@ final class EmInbox implements Inbox {
         ignore = Inbox.BoutNotFoundException.class
     )
     public Bout bout(final long number) throws Inbox.BoutNotFoundException {
-        return new EmBout(this.origin.bout(number), this.postman);
+        return new EmBout(this.origin.bout(number), this.self, this.postman);
     }
 
     @Override
     public Pageable<Bout> jump(final long number) throws IOException {
-        return new EmPageable<>(this.origin.jump(number), this.postman);
+        return new EmPageable<>(
+            this.origin.jump(number),
+            this.self,
+            this.postman
+        );
     }
 
     @Override
@@ -102,7 +113,11 @@ final class EmInbox implements Inbox {
             new Function<Bout, Bout>() {
                 @Override
                 public Bout apply(final Bout input) {
-                    return new EmBout(input, EmInbox.this.postman);
+                    return new EmBout(
+                        input,
+                        EmInbox.this.self,
+                        EmInbox.this.postman
+                    );
                 }
             }
         );

--- a/netbout-web/src/main/java/com/netbout/email/EmMessages.java
+++ b/netbout-web/src/main/java/com/netbout/email/EmMessages.java
@@ -86,7 +86,7 @@ final class EmMessages implements Messages {
      * @param bot Bout we're in
      * @checkstyle ParameterNumberCheck (4 lines)
      */
-    EmMessages(final Messages org, final String slf,
+    EmMessages(final Messages org, @NotNull final String slf,
         final Postman pst, final Bout bot) {
         this.origin = org;
         this.self = slf;
@@ -98,7 +98,7 @@ final class EmMessages implements Messages {
     public void post(final String text) throws IOException {
         this.origin.post(text);
         for (final Friend friend : this.bout.friends().iterate()) {
-            if (friend.email().isEmpty() || this.self == friend.alias()) {
+            if (friend.email().isEmpty() || this.self.equals(friend.alias())) {
                 continue;
             }
             this.email(friend, text);

--- a/netbout-web/src/main/java/com/netbout/email/EmMessages.java
+++ b/netbout-web/src/main/java/com/netbout/email/EmMessages.java
@@ -41,8 +41,8 @@ import com.netbout.spi.Friend;
 import com.netbout.spi.Message;
 import com.netbout.spi.Messages;
 import com.netbout.spi.Pageable;
-import javax.validation.constraints.NotNull;
 import java.io.IOException;
+import javax.validation.constraints.NotNull;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 

--- a/netbout-web/src/main/java/com/netbout/email/EmMessages.java
+++ b/netbout-web/src/main/java/com/netbout/email/EmMessages.java
@@ -33,6 +33,7 @@ import com.jcabi.email.Envelope;
 import com.jcabi.email.Postman;
 import com.jcabi.email.enclosure.EnHTML;
 import com.jcabi.email.stamp.StRecipient;
+import com.jcabi.email.stamp.StSender;
 import com.jcabi.email.stamp.StSubject;
 import com.netbout.rest.Markdown;
 import com.netbout.spi.Bout;
@@ -133,6 +134,7 @@ final class EmMessages implements Messages {
         throws IOException {
         this.postman.send(
             new Envelope.MIME()
+                .with(new StSender(this.self, "no-reply@netbout.com"))
                 .with(new StRecipient(friend.alias(), friend.email()))
                 .with(
                     new StSubject(

--- a/netbout-web/src/main/java/com/netbout/email/EmMessages.java
+++ b/netbout-web/src/main/java/com/netbout/email/EmMessages.java
@@ -63,6 +63,11 @@ final class EmMessages implements Messages {
     private final transient Messages origin;
 
     /**
+     * My own alias.
+     */
+    private final transient String self;
+
+    /**
      * Postman.
      */
     private final transient Postman postman;
@@ -75,11 +80,15 @@ final class EmMessages implements Messages {
     /**
      * Public ctor.
      * @param org Origin
+     * @param slf Self alias
      * @param pst Postman
      * @param bot Bout we're in
+     * @checkstyle ParameterNumberCheck (4 lines)
      */
-    EmMessages(final Messages org, final Postman pst, final Bout bot) {
+    EmMessages(final Messages org, final String slf,
+        final Postman pst, final Bout bot) {
         this.origin = org;
+        this.self = slf;
         this.postman = pst;
         this.bout = bot;
     }
@@ -88,7 +97,7 @@ final class EmMessages implements Messages {
     public void post(final String text) throws IOException {
         this.origin.post(text);
         for (final Friend friend : this.bout.friends().iterate()) {
-            if (friend.email().isEmpty()) {
+            if (friend.email().isEmpty() || this.self == friend.alias()) {
                 continue;
             }
             this.email(friend, text);
@@ -102,7 +111,11 @@ final class EmMessages implements Messages {
 
     @Override
     public Pageable<Message> jump(final long num) throws IOException {
-        return new EmPageable<Message>(this.origin.jump(num), this.postman);
+        return new EmPageable<Message>(
+            this.origin.jump(num),
+            this.self,
+            this.postman
+        );
     }
 
     @Override

--- a/netbout-web/src/main/java/com/netbout/email/EmMessages.java
+++ b/netbout-web/src/main/java/com/netbout/email/EmMessages.java
@@ -41,6 +41,7 @@ import com.netbout.spi.Friend;
 import com.netbout.spi.Message;
 import com.netbout.spi.Messages;
 import com.netbout.spi.Pageable;
+import javax.validation.constraints.NotNull;
 import java.io.IOException;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;

--- a/netbout-web/src/main/java/com/netbout/email/EmPageable.java
+++ b/netbout-web/src/main/java/com/netbout/email/EmPageable.java
@@ -57,6 +57,11 @@ final class EmPageable<T> implements Pageable<T> {
     private final transient Pageable<T> origin;
 
     /**
+     * Alias of myself.
+     */
+    private final transient String self;
+
+    /**
      * Postman.
      */
     private final transient Postman postman;
@@ -64,16 +69,22 @@ final class EmPageable<T> implements Pageable<T> {
     /**
      * Public ctor.
      * @param org Origin
+     * @param slf Self alias
      * @param pst Postman
      */
-    EmPageable(final Pageable<T> org, final Postman pst) {
+    EmPageable(final Pageable<T> org, final String slf, final Postman pst) {
         this.origin = org;
+        this.self = slf;
         this.postman = pst;
     }
 
     @Override
     public Pageable<T> jump(final long number) throws IOException {
-        return new EmPageable<T>(this.origin.jump(number), this.postman);
+        return new EmPageable<T>(
+            this.origin.jump(number),
+            this.self,
+            this.postman
+        );
     }
 
     @Override
@@ -90,6 +101,7 @@ final class EmPageable<T> implements Pageable<T> {
                     } else {
                         result = new EmBout(
                             Bout.class.cast(input),
+                            EmPageable.this.self,
                             EmPageable.this.postman
                         );
                     }

--- a/netbout-web/src/test/java/com/netbout/email/EmAliasTest.java
+++ b/netbout-web/src/test/java/com/netbout/email/EmAliasTest.java
@@ -71,6 +71,15 @@ public final class EmAliasTest {
         Mockito.verify(postman).send(captor.capture());
         final Message msg = captor.getValue().unwrap();
         MatcherAssert.assertThat(msg.getFrom().length, Matchers.is(1));
+        final InternetAddress from = (InternetAddress) msg.getFrom()[0];
+        MatcherAssert.assertThat(
+            from.getPersonal(),
+            Matchers.is(alias.name())
+        );
+        MatcherAssert.assertThat(
+            from.getAddress(),
+            Matchers.is("no-reply@netbout.com")
+        );
         MatcherAssert.assertThat(msg.getAllRecipients().length, Matchers.is(1));
         MatcherAssert.assertThat(msg.getSubject(), Matchers.startsWith("#1: "));
         final ByteArrayOutputStream baos = new ByteArrayOutputStream();


### PR DESCRIPTION
~~I think the `Messages` interface should be refactored so that the `post` method also takes a `sender` param, so that we can compare the `friend` alias with the `sender` alias. I have added a failing test (with `@Ignore` and a `@todo`).~~

**UPDATE**: I wanted to finish the task, just to learn more about the codebase.

I solved it by adding a chain of "self" aliases from `EmAlias` up to `EmMessages`, copying the pattern from the dynamo service implementations.

Fixes #548 