### PR TITLE
#604 MarkdownTest fails on Windows

### DIFF
--- a/netbout-web/src/test/java/com/netbout/rest/MarkdownTest.java
+++ b/netbout-web/src/test/java/com/netbout/rest/MarkdownTest.java
@@ -110,7 +110,9 @@ public final class MarkdownTest {
         for (final String[] pair : texts) {
             MatcherAssert.assertThat(
                 new Markdown(pair[0]).html().trim(),
-                Matchers.equalTo(pair[1])
+                Matchers.equalTo(
+                    pair[1].replace("\n", System.getProperty("line.separator"))
+                )
             );
         }
     }


### PR DESCRIPTION
Added replacement of `\n` with platform-dependent line.separator. Tested locally by running with `mvn clean install -Pqulice -Dline.separator=$'\r\n'`