### PR TITLE
#609 return after login

### DIFF
--- a/netbout-web/src/main/java/com/netbout/rest/RsReturn.java
+++ b/netbout-web/src/main/java/com/netbout/rest/RsReturn.java
@@ -1,0 +1,82 @@
+/**
+ * Copyright (c) 2009-2015, netbout.com
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are PROHIBITED without prior written permission from
+ * the author. This product may NOT be used anywhere and on any computer
+ * except the server platform of netbout Inc. located at www.netbout.com.
+ * Federal copyright law prohibits unauthorized reproduction by any means
+ * and imposes fines up to $25,000 for violation. If you received
+ * this code accidentally and without intent to use it, please report this
+ * incident to the author by email.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+ * OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+package com.netbout.rest;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.nio.charset.Charset;
+import java.util.Date;
+import java.util.Locale;
+import java.util.concurrent.TimeUnit;
+import org.takes.Response;
+import org.takes.rs.RsWithCookie;
+import org.takes.rs.RsWrap;
+
+/**
+ * Response decorator which sets cookie with return location.
+ *
+ * @author Ivan Inozemtsev (ivan.inozemtsev@gmail.com)
+ * @version $Id$
+ * @since 2.14.13
+ */
+public final class RsReturn extends RsWrap {
+    /**
+     * Ctor.
+     * @param res Response to decorate
+     * @param loc Location to be set as return location
+     * @throws UnsupportedEncodingException If fails
+     */
+    public RsReturn(final Response res, final String loc)
+        throws UnsupportedEncodingException {
+        this(res, loc, RsReturn.class.getSimpleName());
+    }
+    /**
+     * Ctor.
+     * @param res Response to decorate
+     * @param loc Location to be set as return location
+     * @param cookie Cookie name
+     * @throws UnsupportedEncodingException If fails
+     */
+    public RsReturn(final Response res, final String loc, final String cookie)
+        throws UnsupportedEncodingException {
+        super(
+            new RsWithCookie(
+                res,
+                cookie,
+                URLEncoder.encode(loc, Charset.defaultCharset().name()),
+                String.format(
+                    Locale.ENGLISH,
+                    "Expires=%1$ta, %1$td %1$tb %1$tY %1$tT GMT",
+                    new Date(
+                        System.currentTimeMillis()
+                            + TimeUnit.HOURS.toMillis(1L)
+                    )
+            )
+        )
+        );
+    }
+}

--- a/netbout-web/src/main/java/com/netbout/rest/TkApp.java
+++ b/netbout-web/src/main/java/com/netbout/rest/TkApp.java
@@ -36,6 +36,8 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.charset.Charset;
 import java.util.regex.Pattern;
+import org.takes.Request;
+import org.takes.Response;
 import org.takes.Take;
 import org.takes.facets.auth.PsByFlag;
 import org.takes.facets.flash.TkFlash;
@@ -47,6 +49,7 @@ import org.takes.facets.fork.FkParams;
 import org.takes.facets.fork.FkRegex;
 import org.takes.facets.fork.TkFork;
 import org.takes.facets.forward.TkForward;
+import org.takes.rq.RqHref;
 import org.takes.rs.RsRedirect;
 import org.takes.tk.TkClasspath;
 import org.takes.tk.TkFiles;
@@ -168,7 +171,19 @@ public final class TkApp extends TkWrap {
             new FkRegex("/favicon.ico", new TkFavicon()),
             new FkAnonymous(
                 new TkFork(
-                    new FkRegex("/", new TkHome(base))
+                    new FkRegex("/", new TkHome(base)),
+                    new FkFixed(
+                        new Take() {
+                            @Override
+                            public Response act(final Request req)
+                                throws IOException {
+                                return new RsReturn(
+                                    new RsRedirect("/"),
+                                    new RqHref.Base(req).href().bare()
+                                );
+                            }
+                        }
+                    )
                 )
             ),
             new FkAuthenticated(
@@ -176,7 +191,7 @@ public final class TkApp extends TkWrap {
                     new FkRegistered(
                         base,
                         new TkFork(
-                            new FkRegex("/", new TkInbox(base)),
+                            new FkRegex("/", new TkReturn(new TkInbox(base))),
                             new FkRegex("/start", new TkStart(base)),
                             new FkRegex("/b/.*", new TkBout(base)),
                             new FkRegex("/acc/.*", new TkAccount(base)),

--- a/netbout-web/src/main/java/com/netbout/rest/TkReturn.java
+++ b/netbout-web/src/main/java/com/netbout/rest/TkReturn.java
@@ -1,0 +1,95 @@
+/**
+ * Copyright (c) 2009-2015, netbout.com
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are PROHIBITED without prior written permission from
+ * the author. This product may NOT be used anywhere and on any computer
+ * except the server platform of netbout Inc. located at www.netbout.com.
+ * Federal copyright law prohibits unauthorized reproduction by any means
+ * and imposes fines up to $25,000 for violation. If you received
+ * this code accidentally and without intent to use it, please report this
+ * incident to the author by email.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+ * OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+package com.netbout.rest;
+
+import java.io.IOException;
+import java.util.Iterator;
+import lombok.EqualsAndHashCode;
+import org.takes.Request;
+import org.takes.Response;
+import org.takes.Take;
+import org.takes.rq.RqCookies;
+import org.takes.rs.RsRedirect;
+import org.takes.rs.RsWithCookie;
+
+/**
+ * Take that understands Return cookie. If Return cookie
+ * is set, sends redirect response to stored location.
+ * Otherwise delegates to original Take.
+ *
+ * @author Ivan Inozemtsev (ivan.inozemtsev@gmail.com)
+ * @version $Id$
+ * @since 2.14.13
+ */
+@EqualsAndHashCode(of = { "origin", "cookie" })
+final class TkReturn implements Take {
+
+    /**
+     * Original take.
+     */
+    private final transient Take origin;
+
+    /**
+     * Cookie name.
+     */
+    private final transient String cookie;
+
+    /**
+     * Ctor.
+     * @param take Original take
+     */
+    public TkReturn(final Take take) {
+        this(take, RsReturn.class.getSimpleName());
+    }
+
+    /**
+     * Ctor.
+     * @param take Original take
+     * @param name Cookie name
+     */
+    public TkReturn(final Take take, final String name) {
+        this.origin = take;
+        this.cookie = name;
+    }
+
+    @Override
+    public Response act(final Request request) throws IOException {
+        final RqCookies cookies = new RqCookies.Base(request);
+        final Iterator<String> values = cookies.cookie(this.cookie).iterator();
+        final Response response;
+        if (values.hasNext()) {
+            response = new RsWithCookie(
+                new RsRedirect(values.next()),
+                this.cookie,
+                ""
+            );
+        } else {
+            response = this.origin.act(request);
+        }
+        return response;
+    }
+}

--- a/netbout-web/src/test/java/com/netbout/rest/TkAppTest.java
+++ b/netbout-web/src/test/java/com/netbout/rest/TkAppTest.java
@@ -96,9 +96,10 @@ public final class TkAppTest {
     /**
      * TkApp can redirect unauthenticated users to login page
      * and store return location in RsReturn cookie.
-     * @todo #609:30min Currently there is no way to send unauthorized
-     *  request from a test, as there is a PsFake(TkAppAuth.TESTING)
-     *  in TkAppAuth, hence all requests are authorized.
+     * @todo #609:30min We need to be able to send anonymous requests
+     *  from tests to verify correct TkApp behavior for anonymous users.
+     *  But now all requests from tests are authorized because of
+     *  PsFake(TkAppAuth.TESTING) in TkAppAuth.
      * @throws Exception If there is some problem inside
      */
     @Test

--- a/netbout-web/src/test/java/com/netbout/rest/TkAppTest.java
+++ b/netbout-web/src/test/java/com/netbout/rest/TkAppTest.java
@@ -26,21 +26,27 @@
  */
 package com.netbout.rest;
 
+import com.jcabi.urn.URN;
 import com.netbout.mock.MkBase;
 import java.net.HttpURLConnection;
+import java.util.regex.Pattern;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.takes.Take;
 import org.takes.facets.hamcrest.HmRsStatus;
 import org.takes.rq.RqFake;
 import org.takes.rq.RqMethod;
+import org.takes.rq.RqWithHeader;
+import org.takes.rs.RsPrint;
 
 /**
  * Test case for {@link TkApp}.
  * @author Yegor Bugayenko (yegor@teamed.io)
  * @version $Id$
  * @since 2.14
+ * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */
 public final class TkAppTest {
 
@@ -87,4 +93,80 @@ public final class TkAppTest {
         }
     }
 
+    /**
+     * TkApp can redirect unauthenticated users to login page
+     * and store return location in RsReturn cookie.
+     * @todo #609:30min Currently there is no way to send unauthorized
+     *  request from a test, as there is a PsFake(TkAppAuth.TESTING)
+     *  in TkAppAuth, hence all requests are authorized.
+     * @throws Exception If there is some problem inside
+     */
+    @Test
+    @Ignore
+    public void redirectsToLoginAndSetsCookie() throws Exception {
+        final String head = new RsPrint(
+            new TkApp(new MkBase()).act(new RqFake(RqMethod.GET, "/whatever"))
+        ).printHead();
+        MatcherAssert.assertThat(
+            // @checkstyle MultipleStringLiteralsCheck (2 lines)
+            "Incorrect status code",
+            Integer.parseInt(head.split("\\s")[1]),
+            Matchers.equalTo(HttpURLConnection.HTTP_SEE_OTHER)
+        );
+        MatcherAssert.assertThat(
+            // @checkstyle MultipleStringLiteralsCheck (1 line)
+            "Incorrect Location header",
+            Pattern.compile(
+                "^Location: /$",
+                Pattern.MULTILINE
+            ).matcher(head).find()
+        );
+        MatcherAssert.assertThat(
+            // @checkstyle MultipleStringLiteralsCheck (1 line)
+            "Incorrect Set-Cookie header",
+            Pattern.compile(
+                "^Set-Cookie: RsReturn=.*%2Fwhatever;Expires=.*$",
+                Pattern.MULTILINE
+            ).matcher(head).find()
+        );
+    }
+
+    /**
+     * TkApp can redirect authenticated users from home location
+     * to the location of RsReturn cookie.
+     * @throws Exception If there is some problem inside
+     */
+    @Test
+    public void redirectsToReturnCookie() throws Exception {
+        final String head = new RsPrint(
+            new TkApp(new MkBase()).act(
+                new RqWithHeader(
+                    new RqWithTester(new URN("urn:test:1")),
+                    "Cookie: RsReturn=http://example.com/whatever"
+                )
+            )
+        ).printHead();
+        MatcherAssert.assertThat(
+            // @checkstyle MultipleStringLiteralsCheck (3 lines)
+            "Incorrect status code",
+            Integer.parseInt(head.split("\\s")[1]),
+            Matchers.equalTo(HttpURLConnection.HTTP_SEE_OTHER)
+        );
+        MatcherAssert.assertThat(
+            // @checkstyle MultipleStringLiteralsCheck (1 line)
+            "Incorrect Location header",
+            Pattern.compile(
+                "^Location: http://example.com/whatever$",
+                Pattern.MULTILINE
+            ).matcher(head).find()
+        );
+        MatcherAssert.assertThat(
+            // @checkstyle MultipleStringLiteralsCheck (1 line)
+            "Incorrect Set-Cookie header",
+            Pattern.compile(
+                "^Set-Cookie: RsReturn=$",
+                Pattern.MULTILINE
+            ).matcher(head).find()
+        );
+    }
 }


### PR DESCRIPTION
Proposed fix for issue #609.
* New classes `RsReturn` and `TkReturn` are added, similar to `RsFlash`/`TkFlash`
* Anonymous request to any location except `/` uses `RsReturn` to store the location in a cookie and redirects to `/`
* Authenticated request to `/` uses `TkReturn` to check whether there is a return cookie, and if so, sends redirect to return location and clears cookie