### PR TITLE
#546 'View Bout' action in Gmail

### DIFF
--- a/netbout-web/src/main/java/com/netbout/email/EmMessages.java
+++ b/netbout-web/src/main/java/com/netbout/email/EmMessages.java
@@ -152,7 +152,8 @@ final class EmMessages implements Messages {
                                 "http://www.netbout.com/b/%d</p>",
                                 this.bout.number()
                             ),
-                            "</p>"
+                            "</p>",
+                            new GmailViewAction(this.bout.number()).html()
                         )
                     )
                 )

--- a/netbout-web/src/main/java/com/netbout/email/EmMessages.java
+++ b/netbout-web/src/main/java/com/netbout/email/EmMessages.java
@@ -153,7 +153,7 @@ final class EmMessages implements Messages {
                                 this.bout.number()
                             ),
                             "</p>",
-                            new GmailViewAction(this.bout.number()).html()
+                            new GmailViewAction(this.bout.number()).xml()
                         )
                     )
                 )

--- a/netbout-web/src/main/java/com/netbout/email/GmailViewAction.java
+++ b/netbout-web/src/main/java/com/netbout/email/GmailViewAction.java
@@ -69,6 +69,8 @@ final class GmailViewAction {
                     .attr("itemtype", "http://schema.org/ViewAction")
                     .add("link").attr("itemprop", "target")
                     .attr("href", String.format("http://www.netbout.com/b/%d", this.number)).up()
+                    .add("link").attr("itemprop", "url")
+                    .attr("href", String.format("http://www.netbout.com/b/%d", this.number)).up()
                     .add("meta").attr("itemprop", "name").attr("content", "View Bout").up().up()
                     .add("div").attr("itemprop", "publisher").attr("itemscope", "")
                     .attr("itemtype", "http://schema.org/Organization")

--- a/netbout-web/src/main/java/com/netbout/email/GmailViewAction.java
+++ b/netbout-web/src/main/java/com/netbout/email/GmailViewAction.java
@@ -1,0 +1,73 @@
+/**
+ * Copyright (c) 2009-2015, netbout.com
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are PROHIBITED without prior written permission from
+ * the author. This product may NOT be used anywhere and on any computer
+ * except the server platform of netbout Inc. located at www.netbout.com.
+ * Federal copyright law prohibits unauthorized reproduction by any means
+ * and imposes fines up to $25,000 for violation. If you received
+ * this code accidentally and without intent to use it, please report this
+ * incident to the author by email.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+ * OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+package com.netbout.email;
+
+/**
+ * Integrates with Gmail's View Actions.
+ * @author Matteo Barbieri (barbieri.matteo@gmail.com)
+ * @version $Id$
+ */
+final class GmailViewAction {
+
+    /**
+     * The bout number.
+     */
+    private final transient long number;
+
+    /**
+     * Primary ctor.
+     * @param nbr The bout number
+     */
+    GmailViewAction(final long nbr) {
+        this.number = nbr;
+    }
+
+    /**
+     * Returns the HTML for Gmail ViewAction.
+     * @return The HTML
+     * @checkstyle LineLength (15 lines)
+     */
+    @SuppressWarnings("PMD.ConsecutiveLiteralAppends")
+    public String html() {
+        final StringBuilder html = new StringBuilder(540);
+        html.append("<div itemscope itemtype=\"http://schema.org/EmailMessage\">")
+            .append("  <meta itemprop=\"description\" content=\"View Bout\"/>")
+            .append("  <div itemprop=\"potentialAction\" itemscope itemtype=\"http://schema.org/ViewAction\">")
+            .append("    <link itemprop=\"target\" href=\"http://www.netbout.com/b/%d\"/>")
+            .append("    <meta itemprop=\"name\" content=\"View Bout\"/>")
+            .append("  </div>")
+            .append(" <div itemprop=\"publisher\" itemscope itemtype=\"http://schema.org/Organization\">")
+            .append("  <meta itemprop=\"name\" content=\"Netbout\"/>")
+            .append("  <link itemprop=\"url\" href=\"http://www.netbout.com/\"/>")
+            .append(" </div>")
+            .append("</div>");
+        return String.format(
+            html.toString(),
+            this.number
+        );
+    }
+}

--- a/netbout-web/src/main/java/com/netbout/email/GmailViewAction.java
+++ b/netbout-web/src/main/java/com/netbout/email/GmailViewAction.java
@@ -26,6 +26,10 @@
  */
 package com.netbout.email;
 
+import org.xembly.Directives;
+import org.xembly.ImpossibleModificationException;
+import org.xembly.Xembler;
+
 /**
  * Integrates with Gmail's View Actions.
  * @author Matteo Barbieri (barbieri.matteo@gmail.com)
@@ -47,27 +51,32 @@ final class GmailViewAction {
     }
 
     /**
-     * Returns the HTML for Gmail ViewAction.
-     * @return The HTML
-     * @checkstyle LineLength (15 lines)
+     * Returns the XML section for Gmail ViewAction.
+     * @return The XML
+     * @checkstyle LineLength (20 lines)
+     * @checkstyle MultipleStringLiteralsCheck (25 lines)
      */
-    @SuppressWarnings("PMD.ConsecutiveLiteralAppends")
-    public String html() {
-        final StringBuilder html = new StringBuilder(540);
-        html.append("<div itemscope itemtype=\"http://schema.org/EmailMessage\">")
-            .append("  <meta itemprop=\"description\" content=\"View Bout\"/>")
-            .append("  <div itemprop=\"potentialAction\" itemscope itemtype=\"http://schema.org/ViewAction\">")
-            .append("    <link itemprop=\"target\" href=\"http://www.netbout.com/b/%d\"/>")
-            .append("    <meta itemprop=\"name\" content=\"View Bout\"/>")
-            .append("  </div>")
-            .append(" <div itemprop=\"publisher\" itemscope itemtype=\"http://schema.org/Organization\">")
-            .append("  <meta itemprop=\"name\" content=\"Netbout\"/>")
-            .append("  <link itemprop=\"url\" href=\"http://www.netbout.com/\"/>")
-            .append(" </div>")
-            .append("</div>");
-        return String.format(
-            html.toString(),
-            this.number
-        );
+    @SuppressWarnings("PMD.AvoidDuplicateLiterals")
+    public String xml() {
+        try {
+            return new Xembler(
+                new Directives()
+                    .add("div")
+                    .attr("itemscope", "")
+                    .attr("itemtype", "http://schema.org/EmailMessage")
+                    .add("meta").attr("itemprop", "description").attr("content", "View Bout").up()
+                    .add("div").attr("itemprop", "potentialAction").attr("itemscope", "")
+                    .attr("itemtype", "http://schema.org/ViewAction")
+                    .add("link").attr("itemprop", "target")
+                    .attr("href", String.format("http://www.netbout.com/b/%d", this.number)).up()
+                    .add("meta").attr("itemprop", "name").attr("content", "View Bout").up().up()
+                    .add("div").attr("itemprop", "publisher").attr("itemscope", "")
+                    .attr("itemtype", "http://schema.org/Organization")
+                    .add("meta").attr("itemprop", "name").attr("content", "Netbout").up()
+                    .add("link").attr("itemprop", "url").attr("href", "http://www.netbout.com")
+            ).xml();
+        } catch (final ImpossibleModificationException ex) {
+            throw new IllegalStateException(ex);
+        }
     }
 }

--- a/netbout-web/src/main/java/com/netbout/email/GmailViewAction.java
+++ b/netbout-web/src/main/java/com/netbout/email/GmailViewAction.java
@@ -53,8 +53,7 @@ final class GmailViewAction {
     /**
      * Returns the XML section for Gmail ViewAction.
      * @return The XML
-     * @checkstyle LineLength (20 lines)
-     * @checkstyle MultipleStringLiteralsCheck (25 lines)
+     * @checkstyle MultipleStringLiteralsCheck (45 lines)
      */
     @SuppressWarnings("PMD.AvoidDuplicateLiterals")
     public String xml() {
@@ -64,18 +63,40 @@ final class GmailViewAction {
                     .add("div")
                     .attr("itemscope", "")
                     .attr("itemtype", "http://schema.org/EmailMessage")
-                    .add("meta").attr("itemprop", "description").attr("content", "View Bout").up()
-                    .add("div").attr("itemprop", "potentialAction").attr("itemscope", "")
+                    .add("meta")
+                    .attr("itemprop", "description")
+                    .attr("content", "View Bout").up()
+                    .add("div")
+                    .attr("itemprop", "potentialAction")
+                    .attr("itemscope", "")
                     .attr("itemtype", "http://schema.org/ViewAction")
                     .add("link").attr("itemprop", "target")
-                    .attr("href", String.format("http://www.netbout.com/b/%d", this.number)).up()
+                    .attr(
+                        "href",
+                        String.format(
+                            "http://www.netbout.com/b/%d", this.number
+                        )
+                    ).up()
                     .add("link").attr("itemprop", "url")
-                    .attr("href", String.format("http://www.netbout.com/b/%d", this.number)).up()
-                    .add("meta").attr("itemprop", "name").attr("content", "View Bout").up().up()
-                    .add("div").attr("itemprop", "publisher").attr("itemscope", "")
+                    .attr(
+                        "href",
+                        String.format(
+                            "http://www.netbout.com/b/%d", this.number
+                        )
+                    ).up()
+                    .add("meta")
+                    .attr("itemprop", "name")
+                    .attr("content", "View Bout").up().up()
+                    .add("div")
+                    .attr("itemprop", "publisher")
+                    .attr("itemscope", "")
                     .attr("itemtype", "http://schema.org/Organization")
-                    .add("meta").attr("itemprop", "name").attr("content", "Netbout").up()
-                    .add("link").attr("itemprop", "url").attr("href", "http://www.netbout.com")
+                    .add("meta")
+                    .attr("itemprop", "name")
+                    .attr("content", "Netbout").up()
+                    .add("link")
+                    .attr("itemprop", "url")
+                    .attr("href", "http://www.netbout.com")
             ).xml();
         } catch (final ImpossibleModificationException ex) {
             throw new IllegalStateException(ex);

--- a/netbout-web/src/test/java/com/netbout/email/EmMessagesITCase.java
+++ b/netbout-web/src/test/java/com/netbout/email/EmMessagesITCase.java
@@ -69,7 +69,7 @@ public final class EmMessagesITCase {
             baos.toString(), Matchers.containsString(
                 String.format(
                     // @checkstyle LineLength (1 line)
-                    "<link itemprop=\"target\" href=\"http://www.netbout.com/b/%d\"/>",
+                    "<link href=\"http://www.netbout.com/b/%d\" itemprop=\"target\"/>",
                     bout.number()
                 )
             )

--- a/netbout-web/src/test/java/com/netbout/email/EmMessagesITCase.java
+++ b/netbout-web/src/test/java/com/netbout/email/EmMessagesITCase.java
@@ -1,0 +1,78 @@
+/**
+ * Copyright (c) 2009-2015, netbout.com
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are PROHIBITED without prior written permission from
+ * the author. This product may NOT be used anywhere and on any computer
+ * except the server platform of netbout Inc. located at www.netbout.com.
+ * Federal copyright law prohibits unauthorized reproduction by any means
+ * and imposes fines up to $25,000 for violation. If you received
+ * this code accidentally and without intent to use it, please report this
+ * incident to the author by email.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+ * OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+package com.netbout.email;
+
+import com.jcabi.email.Envelope;
+import com.jcabi.email.Postman;
+import com.netbout.mock.MkBase;
+import com.netbout.spi.Alias;
+import com.netbout.spi.Bout;
+import java.io.ByteArrayOutputStream;
+import javax.mail.Message;
+import javax.mail.internet.MimeMultipart;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+
+/**
+ * Integration case for {@link EmMessages}.
+ * @author Matteo Barbieri (barbieri.matteo@gmail.com)
+ * @version $Id$
+ */
+public final class EmMessagesITCase {
+
+    /**
+     * EmMessages can send an email containing Gmail ViewAction code.
+     * @throws Exception If there is some problem inside
+     */
+    @Test
+    public void mailContainsGmailViewActionCode() throws Exception {
+        final Postman postman = Mockito.mock(Postman.class);
+        final MkBase base = new MkBase();
+        final Alias alias = new EmAlias(base.randomAlias(), postman);
+        final Bout bout = alias.inbox().bout(alias.inbox().start());
+        bout.friends().invite(base.randomAlias().name());
+        bout.messages().post("Are you using GMail?");
+        final ArgumentCaptor<Envelope> captor =
+            ArgumentCaptor.forClass(Envelope.class);
+        Mockito.verify(postman).send(captor.capture());
+        final Message msg = captor.getValue().unwrap();
+        final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        MimeMultipart.class.cast(msg.getContent()).writeTo(baos);
+        MatcherAssert.assertThat(
+            baos.toString(), Matchers.containsString(
+                String.format(
+                    // @checkstyle LineLength (1 line)
+                    "<link itemprop=\"target\" href=\"http://www.netbout.com/b/%d\"/>",
+                    bout.number()
+                )
+            )
+        );
+    }
+}


### PR DESCRIPTION
Added HTML code to generate the ViewAction in Gmail as per documentation:
https://developers.google.com/gmail/markup/reference/go-to-action#view_action

Tests performed only by manually printing the mail message.
We need a way to test real mail, or if already there a proper documentation on how to do it.
I will raise an issue on that.
Fixes #546 