### PR TITLE
#664 Disable link detection inside markdown syntax

### DIFF
--- a/netbout-web/src/main/java/com/netbout/rest/Markdown.java
+++ b/netbout-web/src/main/java/com/netbout/rest/Markdown.java
@@ -153,6 +153,7 @@ public final class Markdown {
      */
     private static String formatLinks(final String txt) {
         final String marker = "](";
+        final String html = "=\"";
         final StringBuilder result = new StringBuilder();
         final Matcher matcher = LINK.matcher(txt);
         int start = 0;
@@ -167,7 +168,8 @@ public final class Markdown {
                 Math.min(txt.length(), matcher.end() + 2)
             );
             final String uri = matcher.group();
-            if (marker.equals(suffix) || marker.equals(prefix)) {
+            if (marker.equals(suffix) || marker.equals(prefix)
+                || html.equals(prefix)) {
                 result.append(uri);
             } else {
                 result.append(String.format("[%1$s](%1$s)", uri));

--- a/netbout-web/src/main/java/com/netbout/rest/Markdown.java
+++ b/netbout-web/src/main/java/com/netbout/rest/Markdown.java
@@ -155,7 +155,7 @@ public final class Markdown {
         final String marker = "](";
         final String html = "=\"";
         final StringBuilder result = new StringBuilder();
-        final Matcher matcher = LINK.matcher(txt);
+        final Matcher matcher = Markdown.LINK.matcher(txt);
         int start = 0;
         while (matcher.find(start)) {
             result.append(txt.substring(start, matcher.start()));

--- a/netbout-web/src/main/java/com/netbout/rest/Markdown.java
+++ b/netbout-web/src/main/java/com/netbout/rest/Markdown.java
@@ -33,6 +33,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.util.logging.Level;
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import javax.validation.constraints.NotNull;
 import org.apache.commons.codec.CharEncoding;
@@ -59,20 +60,9 @@ public final class Markdown {
 
     /**
      * Plain link detection pattern.
-     * The regex consists of the following parts:
-     * <ul>
-     * <li>Negative lookbehind to determine we skip properly formatted
-     * links (e.g. [foo](http://bar))</li>
-     * <li>Scheme prefix followed by arbitrary number of URL-valid
-     * characters</li>
-     * <li>Last character &ndash; URL-valid characters with exclusion of common
-     * punctuation like dot, comma, question mark, exclamation mark, semicolon,
-     * colon, and parentheses</li>
-     * </ul>
      */
     private static final Pattern LINK = Pattern.compile(
-        // @checkstyle LineLength (1 line)
-        "(?<!(\\]\\())(https?://[a-zA-Z0-9-._~:/\\?#\\[\\]\\(\\)@!$&'*+,;=%]+[a-zA-Z0-9-_~/#\\[\\]@$&'*+=%])"
+        "https?://[a-zA-Z0-9-._~:/\\?#@!$&'*+,;=%]+[a-zA-Z0-9-_~/#@$&'*+=%]"
     );
 
     /**
@@ -155,11 +145,36 @@ public final class Markdown {
     }
 
     /**
-     * Replace plain links with Markdown syntax.
+     * Replace plain links with Markdown syntax. To make sure it doesn't
+     * replace links inside markdown syntax, it makes sure that characters
+     * before and after link do not match to Markdown link syntax.
      * @param txt Text to find links in
      * @return Text with Markdown-formatted links
      */
     private static String formatLinks(final String txt) {
-        return LINK.matcher(txt).replaceAll("[$2]($2)");
+        final String marker = "](";
+        final StringBuilder result = new StringBuilder();
+        final Matcher matcher = LINK.matcher(txt);
+        int start = 0;
+        while (matcher.find(start)) {
+            result.append(txt.substring(start, matcher.start()));
+            final String prefix = txt.substring(
+                Math.max(0, matcher.start() - 2),
+                matcher.start()
+            );
+            final String suffix = txt.substring(
+                matcher.end(),
+                Math.min(txt.length(), matcher.end() + 2)
+            );
+            final String uri = matcher.group();
+            if (marker.equals(suffix) || marker.equals(prefix)) {
+                result.append(uri);
+            } else {
+                result.append(String.format("[%1$s](%1$s)", uri));
+            }
+            start = matcher.end();
+        }
+        result.append(txt.substring(start));
+        return result.toString();
     }
 }

--- a/netbout-web/src/test/java/com/netbout/rest/MarkdownTest.java
+++ b/netbout-web/src/test/java/com/netbout/rest/MarkdownTest.java
@@ -197,6 +197,10 @@ public final class MarkdownTest {
                 "[http://googl.com]",
                 "<p>[\n<a href=\"http://googl.com\">http://googl.com</a>]</p>",
             },
+            new String[] {
+                "[google](http://www.google.com)",
+                "<p>\n  <a href=\"http://www.google.com\">google</a>\n</p>",
+            },
         };
         for (final String[] pair : texts) {
             MatcherAssert.assertThat(

--- a/netbout-web/src/test/java/com/netbout/rest/MarkdownTest.java
+++ b/netbout-web/src/test/java/com/netbout/rest/MarkdownTest.java
@@ -185,6 +185,14 @@ public final class MarkdownTest {
                 "[foo](http://foo)",
                 "<p>\n  <a href=\"http://foo\">foo</a>\n</p>",
             },
+            new String[] {
+                "[http://bar.com](http://bar.com)",
+                "<p>\n  <a href=\"http://bar.com\">http://bar.com</a>\n</p>",
+            },
+            new String[] {
+                "[http://googl.com]",
+                "<p>[\n<a href=\"http://googl.com\">http://googl.com</a>]</p>",
+            },
         };
         for (final String[] pair : texts) {
             MatcherAssert.assertThat(

--- a/netbout-web/src/test/java/com/netbout/rest/MarkdownTest.java
+++ b/netbout-web/src/test/java/com/netbout/rest/MarkdownTest.java
@@ -166,6 +166,10 @@ public final class MarkdownTest {
     public void detectsLinks() throws Exception {
         final String[][] texts = {
             new String[] {
+                "<a href=\"http://_google_.com\">g</a>",
+                "<p>\n  <a href=\"http://_google_.com\">g</a>\n</p>",
+            },
+            new String[] {
                 "http://foo.com",
                 "<p>\n  <a href=\"http://foo.com\">http://foo.com</a>\n</p>",
             },


### PR DESCRIPTION
Fix for issue #664. Instead of complexifying the regex I've implemented 'manual' check of text before and after link to make sure we are not inside markdown syntax.