### PR TITLE
Fixed #682 puzzle

### DIFF
--- a/netbout-client/src/main/java/com/netbout/client/RtBout.java
+++ b/netbout-client/src/main/java/com/netbout/client/RtBout.java
@@ -147,6 +147,13 @@ final class RtBout implements Bout {
         );
     }
 
+    // @todo #682:30min/DEV Implement getting
+    // subscription status by alias using with REST call
+    @Override
+    public boolean subscription(final String alias) throws IOException {
+        throw new UnsupportedOperationException("#subscription(alias)");
+    }
+
     @Override
     public void subscribe(final boolean subs) throws IOException {
         this.request.fetch()

--- a/netbout-client/src/main/java/com/netbout/client/RtBout.java
+++ b/netbout-client/src/main/java/com/netbout/client/RtBout.java
@@ -147,9 +147,15 @@ final class RtBout implements Bout {
         );
     }
 
-    // @todo #682:30min/DEV Implement getting subscription by alias.
-    //  Should return subscription status for current boat,
-    //  passing friend alias value using REST call.
+    /**
+     * Get subscription by alias.
+     * @param alias Alias to get subscription for
+     * @return Subscription status
+     * @throws IOException If fails
+     * @todo #682:30min/DEV Implement getting subscription by alias.
+     *  Should return subscription status for current boat,
+     *  passing friend alias value using REST call.
+     */
     @Override
     public boolean subscription(final String alias) throws IOException {
         throw new UnsupportedOperationException("#subscription(alias)");

--- a/netbout-client/src/main/java/com/netbout/client/RtBout.java
+++ b/netbout-client/src/main/java/com/netbout/client/RtBout.java
@@ -148,8 +148,8 @@ final class RtBout implements Bout {
     }
 
     // @todo #682:30min/DEV Implement getting subscription by alias.
-    // Should return subscription status for current boat,
-    // passing friend alias value using REST call.
+    //  Should return subscription status for current boat,
+    //  passing friend alias value using REST call.
     @Override
     public boolean subscription(final String alias) throws IOException {
         throw new UnsupportedOperationException("#subscription(alias)");

--- a/netbout-client/src/main/java/com/netbout/client/RtBout.java
+++ b/netbout-client/src/main/java/com/netbout/client/RtBout.java
@@ -147,8 +147,9 @@ final class RtBout implements Bout {
         );
     }
 
-    // @todo #682:30min/DEV Implement getting
-    // subscription status by alias using with REST call
+    // @todo #682:30min/DEV Implement getting subscription by alias.
+    // Should return subscription status for current boat,
+    // passing friend alias value using REST call.
     @Override
     public boolean subscription(final String alias) throws IOException {
         throw new UnsupportedOperationException("#subscription(alias)");

--- a/netbout-client/src/main/java/com/netbout/client/cached/CdBout.java
+++ b/netbout-client/src/main/java/com/netbout/client/cached/CdBout.java
@@ -49,6 +49,7 @@ import lombok.ToString;
 @ToString(includeFieldNames = false)
 @Loggable(Loggable.DEBUG)
 @EqualsAndHashCode(of = "origin")
+@SuppressWarnings("PMD.TooManyMethods")
 public final class CdBout implements Bout {
 
     /**
@@ -98,6 +99,12 @@ public final class CdBout implements Bout {
     @Cacheable
     public boolean subscription() throws IOException {
         return this.origin.subscription();
+    }
+
+    @Override
+    @Cacheable
+    public boolean subscription(final String alias) throws IOException {
+        return this.origin.subscription(alias);
     }
 
     @Override

--- a/netbout-client/src/main/java/com/netbout/client/retry/ReBout.java
+++ b/netbout-client/src/main/java/com/netbout/client/retry/ReBout.java
@@ -51,6 +51,7 @@ import lombok.ToString;
 @ToString(includeFieldNames = false)
 @Loggable(Loggable.DEBUG)
 @EqualsAndHashCode(of = "origin")
+@SuppressWarnings("PMD.TooManyMethods")
 public final class ReBout implements Bout {
 
     /**
@@ -118,6 +119,15 @@ public final class ReBout implements Bout {
     )
     public boolean subscription() throws IOException {
         return this.origin.subscription();
+    }
+
+    @Override
+    @RetryOnFailure(
+        verbose = false, attempts = Tv.TWENTY,
+        delay = Tv.FIVE, unit = TimeUnit.SECONDS
+    )
+    public boolean subscription(final String alias) throws IOException {
+        return this.origin.subscription(alias);
     }
 
     @Override

--- a/netbout-client/src/main/java/com/netbout/mock/MkBout.java
+++ b/netbout-client/src/main/java/com/netbout/mock/MkBout.java
@@ -52,6 +52,7 @@ import lombok.ToString;
 @ToString
 @Loggable(Loggable.DEBUG)
 @EqualsAndHashCode(of = { "sql", "bout", "self" })
+@SuppressWarnings("PMD.TooManyMethods")
 final class MkBout implements Bout {
 
     /**
@@ -130,12 +131,17 @@ final class MkBout implements Bout {
 
     @Override
     public boolean subscription() throws IOException {
+        return this.subscription(this.self);
+    }
+
+    @Override
+    public boolean subscription(final String alias) throws IOException {
         try {
             return new JdbcSession(this.sql.source())
                 // @checkstyle LineLength (1 lines)
                 .sql("SELECT subscription FROM friend WHERE bout = ? and alias = ?")
                 .set(this.bout)
-                .set(this.self)
+                .set(alias)
                 .select(new SingleOutcome<Boolean>(Boolean.class));
         } catch (final SQLException ex) {
             throw new IOException(ex);

--- a/netbout-client/src/main/java/com/netbout/mock/MkFriends.java
+++ b/netbout-client/src/main/java/com/netbout/mock/MkFriends.java
@@ -78,9 +78,11 @@ final class MkFriends implements Friends {
     public void invite(final String friend) throws IOException {
         try {
             new JdbcSession(this.sql.source())
-                .sql("INSERT INTO friend (bout, alias) VALUES (?, ?)")
+                // @checkstyle LineLength (1 line)
+                .sql("INSERT INTO friend (bout, alias, subscription) VALUES (?, ?, ?)")
                 .set(this.bout)
                 .set(friend)
+                .set(1)
                 .insert(Outcome.VOID);
         } catch (final SQLException ex) {
             throw new IOException(ex);

--- a/netbout-client/src/main/java/com/netbout/mock/MkFriends.java
+++ b/netbout-client/src/main/java/com/netbout/mock/MkFriends.java
@@ -82,7 +82,7 @@ final class MkFriends implements Friends {
                 .sql("INSERT INTO friend (bout, alias, subscription) VALUES (?, ?, ?)")
                 .set(this.bout)
                 .set(friend)
-                .set(1)
+                .set(true)
                 .insert(Outcome.VOID);
         } catch (final SQLException ex) {
             throw new IOException(ex);

--- a/netbout-spi/src/main/java/com/netbout/spi/Bout.java
+++ b/netbout-spi/src/main/java/com/netbout/spi/Bout.java
@@ -86,6 +86,14 @@ public interface Bout {
     boolean subscription() throws IOException;
 
     /**
+     * Get subscription by alias.
+     * @param alias Alias to get subscription for
+     * @return Subscription status
+     * @throws IOException If fails
+     */
+    boolean subscription(String alias) throws IOException;
+
+    /**
      * Set subscription.
      * @param subs The subscription type of the bout
      * @throws IOException If fails
@@ -178,6 +186,10 @@ public interface Bout {
         @Override
         public boolean subscription() throws IOException {
             return this.origin.subscription();
+        }
+        @Override
+        public boolean subscription(final String alias) throws IOException {
+            return this.origin.subscription(alias);
         }
     }
 

--- a/netbout-web/src/main/java/com/netbout/cached/CdBout.java
+++ b/netbout-web/src/main/java/com/netbout/cached/CdBout.java
@@ -51,6 +51,7 @@ import lombok.ToString;
 @Loggable(Loggable.DEBUG)
 @ToString(of = "origin")
 @EqualsAndHashCode(of = "origin")
+@SuppressWarnings("PMD.TooManyMethods")
 final class CdBout implements Bout {
 
     /**
@@ -99,6 +100,12 @@ final class CdBout implements Bout {
     @Cacheable(lifetime = Tv.FIVE, unit = TimeUnit.HOURS)
     public boolean subscription() throws IOException {
         return this.origin.subscription();
+    }
+
+    @Override
+    @Cacheable(lifetime = Tv.FIVE, unit = TimeUnit.HOURS)
+    public boolean subscription(final String alias) throws IOException {
+        return this.origin.subscription(alias);
     }
 
     @Override

--- a/netbout-web/src/main/java/com/netbout/email/EmBout.java
+++ b/netbout-web/src/main/java/com/netbout/email/EmBout.java
@@ -49,6 +49,7 @@ import lombok.ToString;
 @Loggable(Loggable.DEBUG)
 @ToString(of = "origin")
 @EqualsAndHashCode(of = "origin")
+@SuppressWarnings("PMD.TooManyMethods")
 final class EmBout implements Bout {
 
     /**
@@ -106,6 +107,11 @@ final class EmBout implements Bout {
     @Override
     public boolean subscription() throws IOException {
         return this.origin.subscription();
+    }
+
+    @Override
+    public boolean subscription(final String alias) throws IOException {
+        return this.origin.subscription(alias);
     }
 
     @Override

--- a/netbout-web/src/main/java/com/netbout/email/EmMessages.java
+++ b/netbout-web/src/main/java/com/netbout/email/EmMessages.java
@@ -93,14 +93,13 @@ final class EmMessages implements Messages {
         this.self = slf;
     }
 
-     // @todo #547:30min/DEV Send email if friend subscribed to bout.
-     //  Friend should be filtered before send email by subscription
     @Override
     public void post(final String text) throws IOException {
         this.origin.post(text);
         for (final Friend friend : this.bout.friends().iterate()) {
             if (friend.email().isEmpty()
-                || friend.alias().equals(this.self)) {
+                || friend.alias().equals(this.self)
+                || !this.bout.subscription(friend.alias())) {
                 continue;
             }
             this.email(friend, text);


### PR DESCRIPTION
This PR fixes #682 puzzle:
>Send email if friend subscribed to bout. Friend should be filtered before send email by subscription

It overloads `subscription` call with `String alias` argument to be able to see if subscription is enabled for particular alias within target bout.

