### PR TITLE
Fixed whitespace that was missing after a link. (Issue #671)

### DIFF
--- a/netbout-web/src/main/java/com/netbout/rest/Markdown.java
+++ b/netbout-web/src/main/java/com/netbout/rest/Markdown.java
@@ -54,6 +54,14 @@ import org.w3c.tidy.Tidy;
 public final class Markdown {
 
     /**
+     * Pattern to look for a missing whitespace between the end of link and the
+     * next word.
+     */
+    private static final Pattern LINK_WHITESPACE = Pattern.compile(
+        "(</a>)(\\w)"
+    );
+
+    /**
      * Tidy.
      */
     private static final Tidy TIDY = Markdown.makeTidy();
@@ -86,11 +94,13 @@ public final class Markdown {
     @RetryOnFailure(verbose = true)
     public String html() {
         synchronized (Markdown.TIDY) {
-            return Markdown.clean(
-                new PegDownProcessor().markdownToHtml(
-                    Markdown.formatLinks(this.text)
+            return LINK_WHITESPACE.matcher(
+                Markdown.clean(
+                    new PegDownProcessor().markdownToHtml(
+                        Markdown.formatLinks(this.text)
+                    )
                 )
-            ).replaceAll("(</a>)(\\w)", "$1 $2");
+            ).replaceAll("$1 $2");
         }
     }
 

--- a/netbout-web/src/main/java/com/netbout/rest/Markdown.java
+++ b/netbout-web/src/main/java/com/netbout/rest/Markdown.java
@@ -90,7 +90,7 @@ public final class Markdown {
                 new PegDownProcessor().markdownToHtml(
                     Markdown.formatLinks(this.text)
                 )
-            );
+            ).replaceAll("(</a>)(\\w)", "$1 $2");
         }
     }
 

--- a/netbout-web/src/test/java/com/netbout/rest/MarkdownTest.java
+++ b/netbout-web/src/test/java/com/netbout/rest/MarkdownTest.java
@@ -43,17 +43,14 @@ public final class MarkdownTest {
      * @throws Exception If there is some problem inside
      */
     @Test
-    public void handleWithespaceAfterLinks() throws Exception {
+    public void handlesWhitespaceAfterLinks() throws Exception {
         MatcherAssert.assertThat(
             new Markdown(
                 "Hi [google](http://www.google.com) how are you?"
             ).html(),
-            Matchers.allOf(
-                Matchers.equalTo(
-                    // @checkstyle LineLengthCheck (1 line)
-                    "<p>Hi \n<a href=\"http://www.google.com\">google</a> how are you?</p>\n"
-                ),
-                Matchers.not(Matchers.containsString("</a>how"))
+            Matchers.equalTo(
+                // @checkstyle LineLengthCheck (1 line)
+                "<p>Hi \n<a href=\"http://www.google.com\">google</a> how are you?</p>\n"
             )
         );
     }

--- a/netbout-web/src/test/java/com/netbout/rest/MarkdownTest.java
+++ b/netbout-web/src/test/java/com/netbout/rest/MarkdownTest.java
@@ -39,6 +39,26 @@ import org.junit.Test;
 public final class MarkdownTest {
 
     /**
+     * Markdown can handle whitespace after links.
+     * @throws Exception If there is some problem inside
+     */
+    @Test
+    public void handleWithespaceAfterLinks() throws Exception {
+        MatcherAssert.assertThat(
+            new Markdown(
+                "Hi [google](http://www.google.com) how are you?"
+            ).html(),
+            Matchers.allOf(
+                Matchers.equalTo(
+                    // @checkstyle LineLengthCheck (1 line)
+                    "<p>Hi \n<a href=\"http://www.google.com\">google</a> how are you?</p>\n"
+                ),
+                Matchers.not(Matchers.containsString("</a>how"))
+            )
+        );
+    }
+
+    /**
      * Markdown can format a text to HTML.
      * @throws Exception If there is some problem inside
      */


### PR DESCRIPTION
Fixed whitespace that was missing after a link.
It was necessary to use a regular expression because JTIDY is configured to import and export the content as XML and this causes that after a "END NODE" the library removes all whitespace characters.