### PR TITLE
 #717 fixes RtAttachment#write() breaks the content 

### DIFF
--- a/netbout-client/src/main/java/com/netbout/client/RtAttachment.java
+++ b/netbout-client/src/main/java/com/netbout/client/RtAttachment.java
@@ -33,6 +33,7 @@ import com.jcabi.http.response.RestResponse;
 import com.jcabi.http.response.XmlResponse;
 import com.jcabi.log.Logger;
 import com.netbout.spi.Attachment;
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.HttpURLConnection;
@@ -41,7 +42,6 @@ import javax.ws.rs.core.MediaType;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang3.CharEncoding;
 
 /**
  * REST attachment.
@@ -118,14 +118,13 @@ final class RtAttachment implements Attachment {
 
     @Override
     public InputStream read() throws IOException {
-        return IOUtils.toInputStream(
+        return new ByteArrayInputStream(
             this.request.fetch()
                 .as(RestResponse.class)
                 .assertStatus(HttpURLConnection.HTTP_OK)
                 .as(XmlResponse.class)
                 .rel(this.xpath("links/link[@rel='download']/@href"))
-                .fetch().body(),
-            CharEncoding.UTF_8
+                .fetch().binary()
         );
     }
 
@@ -142,7 +141,7 @@ final class RtAttachment implements Attachment {
             .queryParam("ctype", ctype)
             .queryParam("etag", etag)
             .back()
-            .body().set(IOUtils.toString(stream, CharEncoding.UTF_8)).back()
+            .body().set(IOUtils.toByteArray(stream)).back()
             .method(Request.POST)
             .header(
                 HttpHeaders.CONTENT_TYPE,

--- a/netbout-client/src/test/java/com/netbout/client/RtAttachmentsITCase.java
+++ b/netbout-client/src/test/java/com/netbout/client/RtAttachmentsITCase.java
@@ -32,8 +32,9 @@ import com.netbout.spi.Attachments;
 import com.netbout.spi.Bout;
 import com.netbout.spi.Inbox;
 import com.netbout.spi.User;
+import java.io.ByteArrayInputStream;
 import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang3.CharEncoding;
+import org.apache.commons.lang3.RandomUtils;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Rule;
@@ -68,16 +69,15 @@ public final class RtAttachmentsITCase {
         final String name = "test";
         attachments.create(name);
         final Attachment attachment = attachments.get(name);
+        final byte[] data = RandomUtils.nextBytes(100);
         attachment.write(
-            IOUtils.toInputStream(
-                "how are you, \u20ac?", CharEncoding.UTF_8
-            ),
+            new ByteArrayInputStream(data),
             Attachment.MARKDOWN,
             Long.toString(System.currentTimeMillis())
         );
         MatcherAssert.assertThat(
-            IOUtils.toString(attachment.read(), CharEncoding.UTF_8),
-            Matchers.containsString("\u20ac")
+            IOUtils.toByteArray(attachment.read()),
+            Matchers.equalTo(data)
         );
         attachments.delete(name);
     }

--- a/netbout-client/src/test/java/com/netbout/client/RtAttachmentsITCase.java
+++ b/netbout-client/src/test/java/com/netbout/client/RtAttachmentsITCase.java
@@ -34,7 +34,6 @@ import com.netbout.spi.Inbox;
 import com.netbout.spi.User;
 import java.io.ByteArrayInputStream;
 import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang3.RandomUtils;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Rule;
@@ -69,7 +68,10 @@ public final class RtAttachmentsITCase {
         final String name = "test";
         attachments.create(name);
         final Attachment attachment = attachments.get(name);
-        final byte[] data = RandomUtils.nextBytes(100);
+        final byte[] data = new byte[Byte.MAX_VALUE - 1];
+        for (int idx = 0; idx < data.length; ++idx) {
+            data[idx] = (byte) idx;
+        }
         attachment.write(
             new ByteArrayInputStream(data),
             Attachment.MARKDOWN,


### PR DESCRIPTION
For #717 

* modified RtAttachment to be able handle a binary content
* modified the unit test