### PR TITLE
Issue #695 - the subscription status frozen

### DIFF
--- a/netbout-web/src/main/java/com/netbout/cached/CdBout.java
+++ b/netbout-web/src/main/java/com/netbout/cached/CdBout.java
@@ -103,7 +103,6 @@ final class CdBout implements Bout {
     }
 
     @Override
-    @Cacheable(lifetime = Tv.FIVE, unit = TimeUnit.HOURS)
     public boolean subscription(final String alias) throws IOException {
         return this.origin.subscription(alias);
     }


### PR DESCRIPTION
https://github.com/yegor256/netbout/issues/695

The issue happens because the CdBout class casches a subscription in invalid way.
See https://github.com/yegor256/netbout/blob/master/netbout-web/src/main/java/com/netbout/cached/CdBout.java#L106
Namely, this class isn't singleton and both accounts have their instance of class.
When account 2 subscribes herself/himself (step 2 or 4), he/she will reset a cache (CdBout.subscription(String alias) in his/her instance of class.
It will not affect the instance this class of account 1.

You will check that with additional step:

- account 1 turns off (she/he can after that turn on the subscription) the subscription (the bell icon)

Now, when account 1 post a message, account 2 will be notified (or not) according his/her subscription settings.

@mbarbieri test is correct, but it pass because Mkbout doesn't use cache.

My test is based on test made by @mbarbieri, but uses DyBout insetad of MkBout.
