### PR TITLE
#842 Show exclamation icon when email is not verified

### DIFF
--- a/netbout-web/src/main/java/com/netbout/rest/XeAlias.java
+++ b/netbout-web/src/main/java/com/netbout/rest/XeAlias.java
@@ -92,13 +92,20 @@ final class XeAlias extends XeWrap {
      * @param alias Alias
      * @return Xembly source
      * @throws IOException If fails
+     * @todo #842:30min/Dev Write test for the logic of generating Xembly for
+     *  {@link Alias} class. It should focus on checking whether tags "email"
+     *  and "newEmail" are properly populated based on input.
      */
     private static XeSource source(final Alias alias) throws IOException {
         final String email;
-        if (alias.email().contains("!")) {
-            email = alias.email().substring(0, alias.email().indexOf('!'));
+        final String newEmail;
+        final String[] emails = alias.email().split("!");
+        if (emails.length > 1) {
+            email = emails[0];
+            newEmail = emails[1];
         } else {
             email = alias.email();
+            newEmail = "";
         }
         return new XeAppend(
             "alias",
@@ -107,7 +114,8 @@ final class XeAlias extends XeWrap {
                     .add("name").set(alias.name()).up()
                     .add("locale").set(alias.locale().toString()).up()
                     .add("photo").set(alias.photo().toString()).up()
-                    .add("email").set(email)
+                    .add("email").set(email).up()
+                    .add("newEmail").set(newEmail)
             )
         );
     }

--- a/netbout-web/src/main/resources/lang/en.xml
+++ b/netbout-web/src/main/resources/lang/en.xml
@@ -54,6 +54,7 @@
     <save.email>save</save.email>
     <your.email>your email address...</your.email>
     <email.empty>give us your email please</email.empty>
+    <email.not.verified>email "%s" is not yet verified</email.not.verified>
     <email.hello>Every time you get a new message in any of your bouts, we
         send a notification email to this address. We don't send anything else
         there, no promotion or marketing materials.</email.hello>

--- a/netbout-web/src/main/scss/layout.scss
+++ b/netbout-web/src/main/scss/layout.scss
@@ -194,11 +194,11 @@ $width: 750px;
   }
 }
 
-#notice {
+.notice {
   position: absolute;
   top: $em;
   left: 0;
-  width: 12 * $em;
+  white-space: nowrap;
   background: white;
   border: 1px solid $color-red;
   color: $color-red;

--- a/netbout-web/src/main/xsl/layout.xsl
+++ b/netbout-web/src/main/xsl/layout.xsl
@@ -171,8 +171,19 @@
                         <xsl:with-param name="length" select="25"/>
                     </xsl:call-template>
                 </a>
+                <xsl:if test="alias/newEmail != ''">
+                    <span class="notice">
+                        <xsl:attribute name="title">
+                            <xsl:call-template name="format">
+                                <xsl:with-param name="text" select="'email.not.verified'"/>
+                                <xsl:with-param name="value" select="alias/newEmail"/>
+                            </xsl:call-template>
+                        </xsl:attribute>
+                        !
+                    </span>
+                </xsl:if>
                 <xsl:if test="alias/email = ''">
-                    <span id="notice">
+                    <span class="notice">
                         <xsl:value-of select="$TEXTS/email.empty"/>
                     </span>
                 </xsl:if>


### PR DESCRIPTION
Original warning:

![selection_001](https://cloud.githubusercontent.com/assets/5467276/11764515/23895c3a-a134-11e5-83b5-243ffaaefc20.png)

Now there is new warning whenever email is not yet verified (contains `!`):

![screenshot from 2015-12-13 00 15 17](https://cloud.githubusercontent.com/assets/5467276/11764514/235fe472-a134-11e5-8239-277a570544a2.png)
Tootip with explanation is displayed when mouse is over the warning area.

Is any additional testing needed? I haven't found any existing tests to the similar features.

Fixes #842.