### PR TITLE
#787 Clear unread messages cache when reading

### DIFF
--- a/netbout-web/src/main/java/com/netbout/cached/CdInbox.java
+++ b/netbout-web/src/main/java/com/netbout/cached/CdInbox.java
@@ -94,6 +94,7 @@ final class CdInbox implements Inbox {
     }
 
     @Override
+    @Cacheable.FlushBefore
     public Iterable<Bout> iterate() throws IOException {
         return Iterables.transform(
             this.origin.iterate(),

--- a/netbout-web/src/test/java/com/netbout/cached/CdInboxTest.java
+++ b/netbout-web/src/test/java/com/netbout/cached/CdInboxTest.java
@@ -1,0 +1,59 @@
+/**
+ * Copyright (c) 2009-2015, netbout.com
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are PROHIBITED without prior written permission from
+ * the author. This product may NOT be used anywhere and on any computer
+ * except the server platform of netbout Inc. located at www.netbout.com.
+ * Federal copyright law prohibits unauthorized reproduction by any means
+ * and imposes fines up to $25,000 for violation. If you received
+ * this code accidentally and without intent to use it, please report this
+ * incident to the author by email.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+ * OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+package com.netbout.cached;
+
+import com.netbout.spi.Inbox;
+import java.util.Collections;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+/**
+ * Test case for {@link CdInbox}.
+ * @author Michal Kordas (kordas.michal@gmail.com)
+ * @version $Id$
+ * @since 2.23
+ */
+public final class CdInboxTest {
+
+    /**
+     * CdInbox can flush unread number.
+     * @throws Exception If there is some problem inside
+     */
+    @Test
+    public void flushesUnreadNumber() throws Exception {
+        final Inbox origin = Mockito.mock(Inbox.class);
+        Mockito.doReturn(1L).doReturn(2L).when(origin).unread();
+        final Inbox inbox = new CdInbox(origin);
+        MatcherAssert.assertThat(inbox.unread(), Matchers.equalTo(1L));
+        MatcherAssert.assertThat(inbox.unread(), Matchers.equalTo(1L));
+        Mockito.doReturn(Collections.emptyList()).when(origin).iterate();
+        inbox.iterate();
+        MatcherAssert.assertThat(inbox.unread(), Matchers.equalTo(2L));
+    }
+}


### PR DESCRIPTION
For #787:
* flushing cache
* test to confirm that caches are cleared and `CdInbox.unread()` do not provide stale value whenever Inbox is refreshed