### PR TITLE
#791 Introduced parallel tests timeout

### DIFF
--- a/netbout-client/pom.xml
+++ b/netbout-client/pom.xml
@@ -155,7 +155,7 @@
             <plugin>
                 <artifactId>maven-failsafe-plugin</artifactId>
                 <configuration>
-              	<parallelTestsTimeoutInSeconds>10</parallelTestsTimeoutInSeconds>
+              		<parallelTestsTimeoutInSeconds>10</parallelTestsTimeoutInSeconds>
                     <systemPropertyVariables>
                         <netbout.token>${netbout.token}</netbout.token>
                     </systemPropertyVariables>

--- a/netbout-client/pom.xml
+++ b/netbout-client/pom.xml
@@ -155,6 +155,7 @@
             <plugin>
                 <artifactId>maven-failsafe-plugin</artifactId>
                 <configuration>
+              	<parallelTestsTimeoutInSeconds>10</parallelTestsTimeoutInSeconds>
                     <systemPropertyVariables>
                         <netbout.token>${netbout.token}</netbout.token>
                     </systemPropertyVariables>

--- a/netbout-client/pom.xml
+++ b/netbout-client/pom.xml
@@ -155,7 +155,6 @@
             <plugin>
                 <artifactId>maven-failsafe-plugin</artifactId>
                 <configuration>
-              		<parallelTestsTimeoutInSeconds>10</parallelTestsTimeoutInSeconds>
                     <systemPropertyVariables>
                         <netbout.token>${netbout.token}</netbout.token>
                     </systemPropertyVariables>

--- a/netbout-client/src/test/java/com/netbout/client/NbRule.java
+++ b/netbout-client/src/test/java/com/netbout/client/NbRule.java
@@ -53,7 +53,7 @@ public final class NbRule implements TestRule {
             System.getProperty("netbout.url", "http://www.netbout.com")
         );
         Assume.assumeNotNull(token);
-        return new ReUser(new CdUser(new RtUser(url, token)));
+        return new CdUser(new RtUser(url, token));
     }
 
     @Override

--- a/netbout-client/src/test/java/com/netbout/client/NbRule.java
+++ b/netbout-client/src/test/java/com/netbout/client/NbRule.java
@@ -27,7 +27,6 @@
 package com.netbout.client;
 
 import com.netbout.client.cached.CdUser;
-import com.netbout.client.retry.ReUser;
 import com.netbout.spi.User;
 import java.net.URI;
 import org.junit.Assume;


### PR DESCRIPTION
As a fix for #791 , I've added the `parallelTestsTimeoutInSeconds` parameter to the `pom.xml` in `netbout-client`. As a result, any network issues causing long delays in the test cases will not affect the build process.

**EDIT**
Made a permanent fix to freeze issue by removing the `ReUser` wrapper class. However, I still think that parallel tests timeout is needed as an overall check in `pom.xml` (though I've removed it for the time being).