### PR TITLE
#900 upgraded netbout-client dependencies

### DIFF
--- a/netbout-client/pom.xml
+++ b/netbout-client/pom.xml
@@ -53,7 +53,7 @@
         <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
-            <version>1.4.186</version>
+            <version>1.4.190</version>
             <optional>true</optional>
         </dependency>
         <dependency>
@@ -101,13 +101,13 @@
         <dependency>
             <groupId>com.sun.jersey</groupId>
             <artifactId>jersey-client</artifactId>
-            <version>1.18.1</version>
+            <version>1.19</version>
             <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>com.jcabi</groupId>
             <artifactId>jcabi-http</artifactId>
-            <version>1.10.4</version>
+            <version>1.14.1</version>
         </dependency>
         <dependency>
             <groupId>com.jcabi</groupId>

--- a/netbout-client/pom.xml
+++ b/netbout-client/pom.xml
@@ -107,7 +107,7 @@
         <dependency>
             <groupId>com.jcabi</groupId>
             <artifactId>jcabi-http</artifactId>
-            <version>1.14.1</version>
+            <version>1.14.2</version>
         </dependency>
         <dependency>
             <groupId>com.jcabi</groupId>


### PR DESCRIPTION
#900 upgraded netbout-client dependencies:
jcabi-http  1.10.4 -> 1.14.1    
h2  1.4.186 -> 1.4.190 
jersey-client   1.18.1 -> 1.19 