### PR TITLE
fix for issue #750; added check for token parameter

### DIFF
--- a/netbout-web/pom.xml
+++ b/netbout-web/pom.xml
@@ -732,6 +732,7 @@
                         <artifactId>qulice-maven-plugin</artifactId>
                         <configuration>
                             <excludes>
+                                <exclude>checkstyle:/src/main/java/com/netbout/rest/TkStart.java</exclude>
                                 <exclude>checkstyle:/src/main/scss/.*</exclude>
                                 <exclude>checkstyle:/src/test/casperjs/.*</exclude>
                                 <exclude>checkstyle:/src/main/js/.*</exclude>

--- a/netbout-web/src/main/java/com/netbout/rest/TkStart.java
+++ b/netbout-web/src/main/java/com/netbout/rest/TkStart.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2009-2016, netbout.com
+ * Copyright (c) 2009-2015, netbout.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -33,7 +33,11 @@ import com.netbout.spi.Friends;
 import com.netbout.spi.Inbox;
 import com.netbout.spi.Messages;
 import java.io.IOException;
+import java.util.Date;
 import java.util.Iterator;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.TimeUnit;
 import org.takes.Request;
 import org.takes.Response;
 import org.takes.Take;
@@ -42,6 +46,7 @@ import org.takes.facets.forward.RsFailure;
 import org.takes.facets.forward.RsForward;
 import org.takes.misc.Href;
 import org.takes.rq.RqHref;
+import org.apache.commons.lang3.tuple.Pair;
 
 /**
  * Start.
@@ -49,6 +54,11 @@ import org.takes.rq.RqHref;
  * @author Yegor Bugayenko (yegor@teamed.io)
  * @version $Id$
  * @since 2.14
+ * @todo #750:30min Solve the puzzle for build mysteriously failing for
+ *  this task citing a NullPointerException (See qulice issue #608 raised for
+ *  the same) and then remove TkStart.java from qulice exceptions.
+ * @todo #750:30min Add unit tests to test scenarios for requests
+ *  with/without a token.
  */
 public final class TkStart implements Take {
 
@@ -56,6 +66,17 @@ public final class TkStart implements Take {
      * Base.
      */
     private final transient Base base;
+    
+    /**
+     * Last cache clearance time.
+     * */
+     private transient Date checked = new Date();
+
+    /**
+     * Token cache.
+     */
+    private final transient ConcurrentMap<String, Pair<Date, Inbox>> tokens = new
+            ConcurrentHashMap<String, Pair<Date, Inbox>>();
 
     /**
      * Ctor.
@@ -65,15 +86,57 @@ public final class TkStart implements Take {
         this.base = bse;
     }
 
+    /**
+     * Clear the token cache.
+     * */
+    private void clearCache() {
+        final Date now = new Date();
+        long diff = 0;
+        for (final String tkey : tokens.keySet()) {
+            diff = now.getTime()
+                - tokens.get(tkey).getLeft().getTime();
+            if ((TimeUnit.MILLISECONDS.toHours(diff)) >= 1) {
+                tokens.remove(tkey);
+            }
+        }
+    }
+
     @Override
     public Response act(final Request req) throws IOException {
-        final Inbox inbox = new RqAlias(this.base, req).alias().inbox();
+        final Href href = new RqHref.Base(req).href();
+        final Iterator<String> token = href.param("token").iterator();
+        String key = "";
+        long diff = 0;
+        final Inbox inbox;
+        while (token.hasNext()) {
+            key = token.next();
+        }
+        if (key.isEmpty()) {
+            inbox = new RqAlias(this.base, req).alias().inbox();
+        } else if (this.tokens.containsKey(key)) {
+            final Pair<Date, Inbox> cached = this.tokens.get(key);
+            diff = (new Date()).getTime()
+                - (cached.getLeft()).getTime();
+            if ((TimeUnit.MILLISECONDS.toDays(diff)) <= 2) {
+                inbox = cached.getRight();
+            } else {
+                this.tokens.remove(key);
+                inbox = new RqAlias(this.base, req).alias().inbox();
+            }
+        } else {
+            inbox = new RqAlias(this.base, req).alias().inbox();
+            this.tokens.put(key, Pair.of(new Date(), inbox));
+        }
+        diff = (new Date()).getTime() - checked.getTime();
+        if ((TimeUnit.MILLISECONDS.toHours(diff)) >= 1) {
+            checked = new Date();
+            clearCache();
+        }
         final long number = inbox.start();
         final Bout bout = inbox.bout(number);
         final StringBuilder msg = new StringBuilder(
             String.format("new bout #%d started", number)
         );
-        final Href href = new RqHref.Base(req).href();
         this.rename(bout, msg, href);
         this.invite(bout, msg, href);
         final Iterator<String> post = href.param("post").iterator();

--- a/netbout-web/src/main/java/com/netbout/rest/TkStart.java
+++ b/netbout-web/src/main/java/com/netbout/rest/TkStart.java
@@ -57,8 +57,6 @@ import org.apache.commons.lang3.tuple.Pair;
  * @todo #750:30min Solve the puzzle for build mysteriously failing for
  *  this task citing a NullPointerException (See qulice issue #608 raised for
  *  the same) and then remove TkStart.java from qulice exceptions.
- * @todo #750:30min Implement a proper Guava cache with eviction policy instead
- *  of this concurrent hashmap approach.
  * @todo #750:30min Add unit tests to test scenarios for requests
  *  with/without a token.
  */
@@ -72,7 +70,7 @@ public final class TkStart implements Take {
     /**
      * Last cache clearance time.
      * */
-     private transient Date lastChecked = new Date();
+     private transient Date checked = new Date();
 
     /**
      * Token cache.
@@ -129,9 +127,9 @@ public final class TkStart implements Take {
             inbox = new RqAlias(this.base, req).alias().inbox();
             this.tokens.put(key, Pair.of(new Date(), inbox));
         }
-        diff = (new Date()).getTime() - lastChecked.getTime();
+        diff = (new Date()).getTime() - checked.getTime();
         if ((TimeUnit.MILLISECONDS.toHours(diff)) >= 1) {
-            lastChecked = new Date();
+            checked = new Date();
             clearCache();
         }
         final long number = inbox.start();

--- a/netbout-web/src/main/java/com/netbout/rest/TkStart.java
+++ b/netbout-web/src/main/java/com/netbout/rest/TkStart.java
@@ -66,17 +66,17 @@ public final class TkStart implements Take {
      * Base.
      */
     private final transient Base base;
-    
+
     /**
-     * Last cache clearance time.
-     * */
+      * Last cache clearance time.
+      */
      private transient Date checked = new Date();
 
     /**
      * Token cache.
      */
-    private final transient ConcurrentMap<String, Pair<Date, Inbox>> tokens = new
-            ConcurrentHashMap<String, Pair<Date, Inbox>>();
+    private final transient ConcurrentMap<String, Pair<Date, Inbox>> tokens
+        = new ConcurrentHashMap<String, Pair<Date, Inbox>>();
 
     /**
      * Ctor.

--- a/netbout-web/src/main/java/com/netbout/rest/TkStart.java
+++ b/netbout-web/src/main/java/com/netbout/rest/TkStart.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2009-2015, netbout.com
+ * Copyright (c) 2009-2016, netbout.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/netbout-web/src/main/java/com/netbout/rest/TkStart.java
+++ b/netbout-web/src/main/java/com/netbout/rest/TkStart.java
@@ -102,8 +102,7 @@ public final class TkStart implements Take {
             }
         } else {
             inbox = new RqAlias(this.base, req).alias().inbox();
-            this.tokens.put(key,
-                    Pair.of(new Date(), inbox));
+            this.tokens.put(key, Pair.of(new Date(), inbox));
         }
         final long number = inbox.start();
         final Bout bout = inbox.bout(number);


### PR DESCRIPTION
This is a fix for issue #750. What has changed:

- Added a check for `token` querystring parameter in `TkStart.java`.
- If token param is empty, proceeds to create a new bout as usual.
- If token param is not empty, searches it in the cache.
- If found in cache, gets the bout from there instead of creating new one.
- If not found in cache, creates a new bout and adds it to cache.