### PR TITLE
#812 Update jcabi-aspects to the latest version

### DIFF
--- a/netbout-web/pom.xml
+++ b/netbout-web/pom.xml
@@ -107,7 +107,6 @@
         <dependency>
             <groupId>com.jcabi</groupId>
             <artifactId>jcabi-dynamo</artifactId>
-            <version>0.18.4</version>
         </dependency>
         <dependency>
             <groupId>co.stateful</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -115,7 +115,17 @@
             <dependency>
                 <groupId>com.jcabi</groupId>
                 <artifactId>jcabi-aspects</artifactId>
-                <version>0.22</version>
+                <version>0.22.3</version>
+            </dependency>
+            <dependency>
+                <groupId>com.jcabi</groupId>
+                <artifactId>jcabi-xml</artifactId>
+                <version>0.17.1</version>
+            </dependency>
+            <dependency>
+                <groupId>com.jcabi</groupId>
+                <artifactId>jcabi-dynamo</artifactId>
+                <version>0.19</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
For #812:
*  updated jcabi-aspects to 0.22.3
* rest of updates were needed to make build passing for various reasons (mainly lack of compatibility)