### PR TITLE
#883 Frame for code in preview is too wide and causes visual glitch

### DIFF
--- a/netbout-web/src/main/scss/preview.scss
+++ b/netbout-web/src/main/scss/preview.scss
@@ -78,6 +78,7 @@
     content: 'H';
     .content {
       content: 'I';
+      width: 100%;
     }
   }
   .tab-panel {


### PR DESCRIPTION
For #883
 -Added width to the .container scss class, this tells the container to take 100% of the width.