### PR TITLE
947 fixed the email validation

### DIFF
--- a/netbout-web/src/main/java/com/netbout/dynamo/DyAlias.java
+++ b/netbout-web/src/main/java/com/netbout/dynamo/DyAlias.java
@@ -74,7 +74,7 @@ final class DyAlias implements Alias {
         //@checkstyle LineLengthCheck (1 line)
         final String valid = "([a-z0-9_-]+\\.)*[a-z0-9_-]+@[a-z0-9_-]+(\\.[a-z0-9_-]+)*\\.[a-z]{2,6}";
         MAIL = Pattern.compile(
-            String.format("%s|%s!%s", valid, valid, valid),
+            String.format("!?%s|%s!%s", valid, valid, valid),
             Pattern.CASE_INSENSITIVE
         );
     }

--- a/netbout-web/src/main/java/com/netbout/rest/account/TkSaveEmail.java
+++ b/netbout-web/src/main/java/com/netbout/rest/account/TkSaveEmail.java
@@ -50,6 +50,9 @@ import org.takes.rq.RqHref;
  * @version $Id$
  * @since 2.14
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
+ * @todo #947:30min TkSaveEmail shouldn't validate a email when running
+ *  locally. One idea how to know Netbout running locally or not is
+ *  checking Version attribute from MANIFEST for substring LOCAL
  */
 final class TkSaveEmail implements Take {
 

--- a/netbout-web/src/test/java/com/netbout/dynamo/DyAliasITCase.java
+++ b/netbout-web/src/test/java/com/netbout/dynamo/DyAliasITCase.java
@@ -71,14 +71,26 @@ public final class DyAliasITCase {
      * DyAlias can reject invalid email.
      * @throws Exception If there is some problem inside
      */
-    @Test(expected = Alias.InvalidEmailException.class)
-    public void rejectsInvalidEmail() throws Exception {
+    @Test
+    public void rejectsInvalidEmails() throws Exception {
         final Aliases aliases =
             new DyBase().user(new URN("urn:test:13")).aliases();
         final String name = "max";
         aliases.add(name);
         final Alias alias = aliases.iterate().iterator().next();
-        alias.email("test");
+        final String[] emails = {
+            "test", "!test@domain.com!test@domain.com",
+            "!!test@domain.com", "!test@domain!.com!test@domain.com",
+        };
+        int errors = 0;
+        for (final String email: emails) {
+            try {
+                alias.email(email);
+            } catch (final Alias.InvalidEmailException ex) {
+                ++errors;
+            }
+        }
+        MatcherAssert.assertThat(errors, Matchers.is(emails.length));
     }
 
     /**
@@ -95,6 +107,7 @@ public final class DyAliasITCase {
         final String[] emails = {
             "test@domain.com", "test@domain.com!test@domain.com",
             "first.second@sub.domain.com", "UpperCase@Mail.com",
+            "!empty@mail.com",
         };
         for (final String email: emails) {
             alias.email(email);


### PR DESCRIPTION
for #947 

* fixed regexp for the case when email was be empty before the changing
* added unit tests
* created a new puzzle to disable the email validation when Netbout running localy.
  it doesn't make sense to send a verification link when we haven't access to email server
