### PR TITLE
#954 Add unit tests to test scenarios for requests with/without a token

### DIFF
--- a/netbout-web/src/main/java/com/netbout/rest/TkStart.java
+++ b/netbout-web/src/main/java/com/netbout/rest/TkStart.java
@@ -57,8 +57,6 @@ import org.apache.commons.lang3.tuple.Pair;
  * @todo #750:30min Solve the puzzle for build mysteriously failing for
  *  this task citing a NullPointerException (See qulice issue #608 raised for
  *  the same) and then remove TkStart.java from qulice exceptions.
- * @todo #750:30min Add unit tests to test scenarios for requests
- *  with/without a token.
  */
 public final class TkStart implements Take {
 

--- a/netbout-web/src/test/java/com/netbout/rest/bout/TkStartTest.java
+++ b/netbout-web/src/test/java/com/netbout/rest/bout/TkStartTest.java
@@ -62,7 +62,7 @@ import org.takes.rs.RsPrint;
  *  discarded.
  * @todo #750:30min TkStart should not create new bout
  * when same token is specified. Currently set the test case
- * as ignored. See issue #954 for findings.
+ * as ignored.
  * @since 2.15
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */

--- a/netbout-web/src/test/java/com/netbout/rest/bout/TkStartTest.java
+++ b/netbout-web/src/test/java/com/netbout/rest/bout/TkStartTest.java
@@ -44,6 +44,7 @@ import java.util.regex.Pattern;
 import org.apache.commons.lang3.CharEncoding;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.takes.facets.auth.RqWithAuth;
 import org.takes.facets.forward.TkForward;
@@ -59,6 +60,9 @@ import org.takes.rs.RsPrint;
  *  should be added, e.g. when a friend is not found, the error
  *  should be reported correctly and bout creation should be
  *  discarded.
+ * @todo #750:30min TkStart should not create new bout
+ * when same token is specified. Currently set the test case
+ * as ignored. See issue #954 for findings.
  * @since 2.15
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */
@@ -245,6 +249,7 @@ public final class TkStartTest {
      *
      * @throws Exception If there is some problem inside
      */
+    @Ignore("#750 not ready yet")
     @Test
     @SuppressWarnings("PMD.AvoidInstantiatingObjectsInLoops")
     public void handlesToken() throws Exception {

--- a/netbout-web/src/test/java/com/netbout/rest/bout/TkStartTest.java
+++ b/netbout-web/src/test/java/com/netbout/rest/bout/TkStartTest.java
@@ -61,8 +61,8 @@ import org.takes.rs.RsPrint;
  *  should be reported correctly and bout creation should be
  *  discarded.
  * @todo #750:30min TkStart should not create new bout
- * when same token is specified. Currently set the test case
- * as ignored.
+ *  when same token is specified. Currently set the test case
+ *  as ignored.
  * @since 2.15
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */

--- a/netbout-web/src/test/java/com/netbout/rest/bout/TkStartTest.java
+++ b/netbout-web/src/test/java/com/netbout/rest/bout/TkStartTest.java
@@ -61,8 +61,8 @@ import org.takes.rs.RsPrint;
  *  should be reported correctly and bout creation should be
  *  discarded.
  * @todo #954:30min TkStart should not create new bout
- *  when same token is specified. Currently set the test case
- *  "handlesToken" as ignored.
+ *  when same token is specified. When this is fixed, remove @Ignore from
+ *  handlesTokens test
  * @since 2.15
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */

--- a/netbout-web/src/test/java/com/netbout/rest/bout/TkStartTest.java
+++ b/netbout-web/src/test/java/com/netbout/rest/bout/TkStartTest.java
@@ -38,10 +38,10 @@ import com.netbout.spi.Message;
 import com.netbout.spi.User;
 import java.io.IOException;
 import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.Iterator;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import org.apache.commons.lang3.CharEncoding;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Ignore;
@@ -60,9 +60,9 @@ import org.takes.rs.RsPrint;
  *  should be added, e.g. when a friend is not found, the error
  *  should be reported correctly and bout creation should be
  *  discarded.
- * @todo #750:30min TkStart should not create new bout
+ * @todo #954:30min TkStart should not create new bout
  *  when same token is specified. Currently set the test case
- *  as ignored.
+ *  "handlesToken" as ignored.
  * @since 2.15
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */
@@ -155,7 +155,10 @@ public final class TkStartTest {
                         String.format(
                             "/start?post=message&invite=%s&rename=%s",
                             base.randomAlias().name(),
-                            URLEncoder.encode(name, CharEncoding.UTF_8)
+                            URLEncoder.encode(
+                                name,
+                                StandardCharsets.UTF_8.name()
+                            )
                         )
                     )
                 )
@@ -264,10 +267,10 @@ public final class TkStartTest {
             "I am new too",
             "Another new",
         };
+        final String same = "13579";
         final String[] tokens = {
-            // @checkstyle MultipleStringLiteralsCheck (2 lines)
-            "13579",
-            "13579",
+            same,
+            same,
             "24680",
             "",
             "",
@@ -284,11 +287,11 @@ public final class TkStartTest {
                                 "/start?post=%s&token=%s",
                                 URLEncoder.encode(
                                     msgs[count],
-                                    CharEncoding.UTF_8
+                                    StandardCharsets.UTF_8.name()
                                 ),
                                 URLEncoder.encode(
                                     tokens[count],
-                                    CharEncoding.UTF_8
+                                    StandardCharsets.UTF_8.name()
                                 )
                             )
                         )


### PR DESCRIPTION
For #954 
- added test case for token handling
- since #750 is not fully resolved, the test case is set as ignored and puzzle added