### PR TITLE
#945 keep leading spaces for code markdown

### DIFF
--- a/netbout-web/src/main/java/com/netbout/dynamo/DyMessages.java
+++ b/netbout-web/src/main/java/com/netbout/dynamo/DyMessages.java
@@ -167,7 +167,7 @@ final class DyMessages implements Messages {
 
     @Override
     public void post(final String text) throws IOException {
-        final String clean = StringUtils.strip(text);
+        final String clean = StringUtils.stripEnd(text, null);
         if (clean.isEmpty()) {
             throw new Messages.BrokenPostException(
                 "empty message content is not allowed"

--- a/netbout-web/src/test/java/com/netbout/dynamo/DyMessagesITCase.java
+++ b/netbout-web/src/test/java/com/netbout/dynamo/DyMessagesITCase.java
@@ -128,4 +128,31 @@ public final class DyMessagesITCase {
             !result.hasNext()
         );
     }
+
+    /**
+     * DyMessages can retain leading spaces as code markdown.
+     * @throws Exception If there is some problem inside
+     */
+    @Test
+    public void codeMarkdownInMessages() throws Exception {
+        final String alias = "rokit";
+        final Aliases aliases =
+            new DyBase().user(new URN("urn:test:75065")).aliases();
+        aliases.add(alias);
+        final Inbox inbox = aliases.iterate().iterator().next().inbox();
+        final Bout bout = inbox.bout(inbox.start());
+        final String before = "    4 leading spaces retained  ";
+        final String after  = "    4 leading spaces retained";
+        bout.messages().post(before);
+        final Iterator<Message> result =
+            bout.messages().search(after).iterator();
+        MatcherAssert.assertThat(
+            "no matching result found",
+            result.hasNext()
+        );
+        MatcherAssert.assertThat(
+            result.next().text(),
+            Matchers.equalTo(after)
+        );
+    }
 }

--- a/netbout-web/src/test/java/com/netbout/dynamo/DyMessagesITCase.java
+++ b/netbout-web/src/test/java/com/netbout/dynamo/DyMessagesITCase.java
@@ -141,18 +141,16 @@ public final class DyMessagesITCase {
         aliases.add(alias);
         final Inbox inbox = aliases.iterate().iterator().next().inbox();
         final Bout bout = inbox.bout(inbox.start());
-        final String before = "    4 leading spaces retained  ";
-        final String after  = "    4 leading spaces retained";
-        bout.messages().post(before);
+        bout.messages().post("    4 leading spaces retained  ");
         final Iterator<Message> result =
-            bout.messages().search(after).iterator();
+            bout.messages().iterate().iterator();
         MatcherAssert.assertThat(
-            "no matching result found",
+            "expected message not found",
             result.hasNext()
         );
         MatcherAssert.assertThat(
             result.next().text(),
-            Matchers.equalTo(after)
+            Matchers.equalTo("    4 leading spaces retained")
         );
     }
 }


### PR DESCRIPTION
For issue #945 
- don't strip leading spaces as four spaces are treated as `code` markdown