### PR TITLE
#943 - added check for correct copyright years (2009 - current)

### DIFF
--- a/.rultor.yml
+++ b/.rultor.yml
@@ -44,6 +44,7 @@ merge:
     mvn clean
     pdd --source=$(pwd) --verbose --file=/dev/null
     est --dir=est --file=/dev/null
+    ./years.sh
   commanders:
   - caarlos0
   - carlosmiranda

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,3 +20,4 @@ script:
   - mvn clean
   - pdd --source=$(pwd) --file=/dev/null
   - est --dir=est --file=/dev/null
+  - ./years.sh

--- a/netbout-client/src/site/apt/index.apt.vm
+++ b/netbout-client/src/site/apt/index.apt.vm
@@ -7,7 +7,7 @@
  ------
 
 ~~
-~~ Copyright (c) 2009-2015, netbout.com
+~~ Copyright (c) 2009-2016, netbout.com
 ~~ All rights reserved.
 ~~
 ~~ Redistribution and use in source and binary forms, with or without

--- a/netbout-spi/src/site/apt/index.apt.vm
+++ b/netbout-spi/src/site/apt/index.apt.vm
@@ -7,7 +7,7 @@
  ------
 
 ~~
-~~ Copyright (c) 2009-2015, netbout.com
+~~ Copyright (c) 2009-2016, netbout.com
 ~~ All rights reserved.
 ~~
 ~~ Redistribution and use in source and binary forms, with or without

--- a/netbout-web/src/main/js/bout.js
+++ b/netbout-web/src/main/js/bout.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2009-2015, netbout.com
+ * Copyright (c) 2009-2016, netbout.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/netbout-web/src/main/js/friends.js
+++ b/netbout-web/src/main/js/friends.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2009-2015, netbout.com
+ * Copyright (c) 2009-2016, netbout.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/netbout-web/src/site/apt/index.apt.vm
+++ b/netbout-web/src/site/apt/index.apt.vm
@@ -7,7 +7,7 @@
  ------
 
 ~~
-~~ Copyright (c) 2009-2015, netbout.com
+~~ Copyright (c) 2009-2016, netbout.com
 ~~ All rights reserved.
 ~~
 ~~ Redistribution and use in source and binary forms, with or without

--- a/src/site/apt/index.apt.vm
+++ b/src/site/apt/index.apt.vm
@@ -7,7 +7,7 @@
  ------
 
 ~~
-~~ Copyright (c) 2009-2015, netbout.com
+~~ Copyright (c) 2009-2016, netbout.com
 ~~ All rights reserved.
 ~~
 ~~ Redistribution and use in source and binary forms, with or without

--- a/years.sh
+++ b/years.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+if (grep -L -r 2009-`date +%Y` --exclude-dir ".git" --exclude-dir ".settings" --exclude ".*" --exclude-dir "est" --exclude "*.yml" --exclude "*.md" --exclude-dir "target" --exclude-dir "node_modules" --exclude-dir "node" . | egrep -v "(src/site/resources/CNAME|netbout-web/src/test|netbout-web/src/main/scss/jqueryTextcomplete.scss|netbout-web/src/main/bower/postinstall.sh|netbout-web/src/main/resources/com/netbout/rest/error.html.vm|netbout-web/src/main/resources/META-INF/MANIFEST.MF|netbout-web/bower.json|src/main/aspect/README.txt|system.properties|Procfile|deploy.sh|years.sh)"); then
+    echo "Files above have wrong years in copyrights"
+    exit 1
+else
+    exit 0;
+fi
+

--- a/years.sh
+++ b/years.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-if (grep -L -r 2009-`date +%Y` --exclude-dir ".git" --exclude-dir ".settings" --exclude ".*" --exclude-dir "est" --exclude "*.yml" --exclude "*.md" --exclude-dir "target" --exclude-dir "node_modules" --exclude-dir "node" . | egrep -v "(src/site/resources/CNAME|netbout-web/src/test|netbout-web/src/main/scss/jqueryTextcomplete.scss|netbout-web/src/main/bower/postinstall.sh|netbout-web/src/main/resources/com/netbout/rest/error.html.vm|netbout-web/src/main/resources/META-INF/MANIFEST.MF|netbout-web/bower.json|src/main/aspect/README.txt|system.properties|Procfile|deploy.sh|years.sh)"); then
+if (grep -L -r 2009-`date +%Y` --exclude-dir ".git" --exclude-dir ".settings" --exclude ".*" --exclude-dir "est" --exclude "*.yml" --exclude "*.md" --exclude "*findbug*.xml" --exclude-dir "target" --exclude-dir "node_modules" --exclude-dir "node" . | egrep -v "(src/site/resources/CNAME|netbout-web/src/test|netbout-web/src/main/scss/jqueryTextcomplete.scss|netbout-web/src/main/bower/postinstall.sh|netbout-web/src/main/resources/com/netbout/rest/error.html.vm|netbout-web/src/main/resources/META-INF/MANIFEST.MF|netbout-web/bower.json|src/main/aspect/README.txt|system.properties|Procfile|deploy.sh|years.sh)"); then
     echo "Files above have wrong years in copyrights"
     exit 1
 else

--- a/years.sh
+++ b/years.sh
@@ -3,7 +3,4 @@
 if (grep -L -r 2009-`date +%Y` --exclude-dir ".git" --exclude-dir ".settings" --exclude ".*" --exclude-dir "est" --exclude "*.yml" --exclude "*.md" --exclude "*findbug*.xml" --exclude-dir "target" --exclude-dir "node_modules" --exclude-dir "node" . | egrep -v "(src/site/resources/CNAME|netbout-web/src/test|netbout-web/src/main/scss/jqueryTextcomplete.scss|netbout-web/src/main/bower/postinstall.sh|netbout-web/src/main/resources/com/netbout/rest/error.html.vm|netbout-web/src/main/resources/META-INF/MANIFEST.MF|netbout-web/bower.json|src/main/aspect/README.txt|system.properties|Procfile|deploy.sh|years.sh)"); then
     echo "Files above have wrong years in copyrights"
     exit 1
-else
-    exit 0;
 fi
-


### PR DESCRIPTION
Fixes #943: check for CI and rultor for years in copyright by greping trough all files that have a copyright if the years are set correct and add this to the build scripts