### PR TITLE
Obsolete text field "attachment name..."

### DIFF
--- a/netbout-web/src/main/java/com/netbout/rest/bout/TkAttach.java
+++ b/netbout-web/src/main/java/com/netbout/rest/bout/TkAttach.java
@@ -37,10 +37,10 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.StandardCopyOption;
-import java.nio.charset.StandardCharsets;
-import java.net.URLDecoder;
 import java.util.Collection;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -65,7 +65,7 @@ import org.takes.rq.RqMultipart;
  * @since 2.14
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */
-//@SuppressWarnings("PMD.ExcessiveImports")
+@SuppressWarnings("PMD.ExcessiveImports")
 final class TkAttach implements Take {
 
     /**
@@ -149,19 +149,21 @@ final class TkAttach implements Take {
      */
     private String filename(final RqMultipart.Smart form, final Request file)
         throws IOException {
-    	final String name;
-    	Iterable<Request> requests = form.part("name");
-    	if (requests.iterator().hasNext()) {
-            name = IOUtils.toString(requests.iterator().next().body(),
-                StandardCharsets.UTF_8);
+        final String name;
+        final Iterable<Request> requests = form.part("name");
+        if (requests.iterator().hasNext()) {
+            name = IOUtils.toString(
+                requests.iterator().next().body(),
+                StandardCharsets.UTF_8
+            );
         } else {
-        	name = "";
+            name = "";
         }
         final String filename;
         if (StringUtils.isBlank(name)) {
             filename = this.nameFromFile(file);
         } else {
-        	filename = name;
+            filename = name;
         }
         return filename;
     }
@@ -194,8 +196,11 @@ final class TkAttach implements Take {
      */
     private void copyAndValidate(final Request src, final File dst,
         final String name) throws IOException {
-    	Files.copy(src.body(), dst.toPath(),
-    	    StandardCopyOption.REPLACE_EXISTING);
+        Files.copy(
+            src.body(),
+            dst.toPath(),
+            StandardCopyOption.REPLACE_EXISTING
+        );
         this.validate(dst, name);
     }
 

--- a/netbout-web/src/main/js/bout.js
+++ b/netbout-web/src/main/js/bout.js
@@ -27,6 +27,18 @@
 
 /*globals $:false, document:false, window:false */
 
+function cleanFilename(name) {
+  /* jslint forbidds [^a-z], but it's needed here */
+  /*jslint regexp: false*/
+  var cleaned = name.split(/[\/\\]/).pop()
+    .replace(/[^a-zA-Z\.\-0-9]+/g, "-")
+    .replace(/[\-]+/g, "-")
+    .replace(/^-/, "")
+    .replace(/-$/, "");
+  /*jslint regexp: true*/
+  return cleaned;
+}
+
 function escapeHTML(txt) {
   "use strict";
   return txt.replace(/&/g, '&amp;')

--- a/netbout-web/src/main/xsl/bout.xsl
+++ b/netbout-web/src/main/xsl/bout.xsl
@@ -221,7 +221,7 @@
                     enctype="multipart/form-data">
                     <fieldset>
                         <input id="file-name" name="name" autocomplete="off" placeholder="attachment name..." size="30" maxlength="50"/>
-                        <input id="file-binary" name="file" type="file"/>
+                        <input id="file-binary" name="file" type="file" onchange="$('#file-name').val(cleanFilename($(this).val()))" />
                         <label for="file-submit"/>
                         <input id="file-submit" type="submit" value="Upload"/>
                     </fieldset>

--- a/netbout-web/src/test/java/com/netbout/rest/bout/TkAttachTest.java
+++ b/netbout-web/src/test/java/com/netbout/rest/bout/TkAttachTest.java
@@ -187,11 +187,11 @@ public final class TkAttachTest {
      * @throws Exception If there is some problem inside
      */
     @Test
-    public void setAttachementName() throws Exception {
+    public void takeAttachementNameFromField() throws Exception {
         final MkBase base = new MkBase();
-        final String urn = "urn:test:3";
+        final String urn = "urn:test:4";
         final User user = base.user(new URN(urn));
-        user.aliases().add("jeff3");
+        user.aliases().add("jeff4");
         final Alias alias = user.aliases().iterate().iterator().next();
         final long number = alias.inbox().start();
         final Bout bout = alias.inbox().bout(number);
@@ -206,8 +206,8 @@ public final class TkAttachTest {
                     TkAttachTest.body(""),
                     String.format(TkAttachTest.POST_URL, number),
                     //@checkstyle LineLengthCheck (1 line)
-                    String.format("Content-Disposition: form-data; name=\"file\"; filename=\"%s\"", filename),
-                    "Content-Type: application/octet-stream"
+                    String.format("Content-Disposition: form-data; filename=\"%s\"; name=\"file\"", filename),
+                    "Content-Type: application/json"
                 ),
                 new RqWithHeaders(
                     TkAttachTest.body(name),

--- a/netbout-web/src/test/java/com/netbout/rest/bout/TkAttachTest.java
+++ b/netbout-web/src/test/java/com/netbout/rest/bout/TkAttachTest.java
@@ -183,6 +183,54 @@ public final class TkAttachTest {
     }
 
     /**
+     * Take attachement name from name field if value is set.
+     * @throws Exception If there is some problem inside
+     */
+    @Test
+    public void setAttachementName() throws Exception {
+        final MkBase base = new MkBase();
+        final String urn = "urn:test:3";
+        final User user = base.user(new URN(urn));
+        user.aliases().add("jeff3");
+        final Alias alias = user.aliases().iterate().iterator().next();
+        final long number = alias.inbox().start();
+        final Bout bout = alias.inbox().bout(number);
+        bout.friends().invite(alias.name());
+        final String name = "test.jpg";
+        final String filename = "tt.jpg";
+        final RqWithAuth request = new RqWithAuth(
+            urn,
+            new RqMultipart.Fake(
+                TkAttachTest.fake(number),
+                new RqWithHeaders(
+                    TkAttachTest.body(""),
+                    String.format(TkAttachTest.POST_URL, number),
+                    //@checkstyle LineLengthCheck (1 line)
+                    String.format("Content-Disposition: form-data; name=\"file\"; filename=\"%s\"", filename),
+                    "Content-Type: application/octet-stream"
+                ),
+                new RqWithHeaders(
+                    TkAttachTest.body(name),
+                    String.format(TkAttachTest.POST_URL, number),
+                    "Content-Disposition: form-data; name=\"name\""
+                )
+            )
+        );
+        try {
+            new FkBout(".++", new TkAttach(base)).route(request);
+        } catch (final RsForward response) {
+            MatcherAssert.assertThat(
+                response,
+                new HmRsStatus(HttpURLConnection.HTTP_SEE_OTHER)
+            );
+        }
+        MatcherAssert.assertThat(
+            bout.messages().iterate().iterator().next().text(),
+            Matchers.containsString(String.format("attachment \"%s\"", name))
+        );
+    }
+
+    /**
      * Creates fake request for the provided bout number.
      * @param number Bout number
      * @return Fake request


### PR DESCRIPTION
See #865. This patch adds a js function that fills the attachement name field when a file is selected for upload. The user can change the name then. At upload, the name is taken for the attachement if given, the name of the uploaded file otherwise.

I had to add to suppress the ExcessiveImports warning, maybe create a puzzle for it?