### PR TITLE
Trying to invite alias with long string causes not handled exception #864

### DIFF
--- a/netbout-web/src/main/java/com/netbout/rest/bout/TkInvite.java
+++ b/netbout-web/src/main/java/com/netbout/rest/bout/TkInvite.java
@@ -49,7 +49,7 @@ import org.takes.rq.RqForm;
  * Invite a friend to the bout.
  *
  * @author Yegor Bugayenko (yegor@teamed.io)
- * @version $Id$
+ * @version $Id: 9ee51b1fdc2de87f03cebf45e3c068b991a95432 $
  * @since 2.14
  * @checkstyle ClassDataAbstractionCouplingCheck (210 lines)
  */
@@ -90,7 +90,7 @@ final class TkInvite implements Take {
         }
         final String check = new RqAlias(this.base, req)
             .user().aliases().check(guest);
-        if (check.isEmpty()) {
+        if (!check.isEmpty()) {
             throw new RsFailure(
                 String.format("incorrect alias \"%s\", try again", guest)
             );

--- a/netbout-web/src/main/java/com/netbout/rest/bout/TkInvite.java
+++ b/netbout-web/src/main/java/com/netbout/rest/bout/TkInvite.java
@@ -49,7 +49,7 @@ import org.takes.rq.RqForm;
  * Invite a friend to the bout.
  *
  * @author Yegor Bugayenko (yegor@teamed.io)
- * @version $Id: 9ee51b1fdc2de87f03cebf45e3c068b991a95432 $
+ * @version $Id$
  * @since 2.14
  * @checkstyle ClassDataAbstractionCouplingCheck (210 lines)
  */

--- a/netbout-web/src/test/java/com/netbout/rest/bout/TkInviteTest.java
+++ b/netbout-web/src/test/java/com/netbout/rest/bout/TkInviteTest.java
@@ -31,6 +31,7 @@ import com.netbout.mock.MkBase;
 import com.netbout.spi.Alias;
 import com.netbout.spi.Bout;
 import com.netbout.spi.User;
+import org.apache.commons.lang3.StringUtils;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Test;
@@ -44,7 +45,7 @@ import org.takes.rq.RqWithHeader;
 /**
  * Test case for {@link TkInvite}.
  * @author Endrigo Antonini (teamed@endrigo.com.br)
- * @version $Id: 1cc7dffb02a2cc1e4f71ee5953e0ccc757dbe9d1 $
+ * @version $Id$
  * @since 2.15.1
  * @checkstyle MultipleStringLiteralsCheck (500 lines)
  * @checkstyle StringLiteralsConcatenationCheck (500 lines)
@@ -97,13 +98,15 @@ public final class TkInviteTest {
      * @throws Exception If there is some problem inside
      */
     @Test (expected = RsFailure.class)
-    public void inviteWithTooLongAlias() throws Exception {
+    public void failsWhenInvitingWithTooLongAlias() throws Exception {
         final MkBase base = new MkBase();
         final String urn = "urn:test:1";
         final User user = base.user(new URN(urn));
-        final String name = "12345678901234567890123456789012345678901234"
-            + "5678901234567890123456789012345678901234567"
-            + "890123456789012345678901234567890";
+        final String name = StringUtils.join(
+            "12345678901234567890123456789012345678901234",
+            "5678901234567890123456789012345678901234567",
+            "890123456789012345678901234567890"
+        );
         user.aliases().add(name);
         final Alias alias = user.aliases().iterate().iterator().next();
         final Bout bout = alias.inbox().bout(alias.inbox().start());
@@ -118,7 +121,7 @@ public final class TkInviteTest {
                                 "/b/%d/invite",
                                 bout.number()
                             ),
-                            "name=" + name
+                            String.format("name=%s", name)
                         )
                     ),
                     "X-Netbout-Bout",

--- a/netbout-web/src/test/java/com/netbout/rest/bout/TkInviteTest.java
+++ b/netbout-web/src/test/java/com/netbout/rest/bout/TkInviteTest.java
@@ -47,10 +47,18 @@ import org.takes.rq.RqWithHeader;
  * @author Endrigo Antonini (teamed@endrigo.com.br)
  * @version $Id$
  * @since 2.15.1
- * @checkstyle MultipleStringLiteralsCheck (500 lines)
- * @checkstyle StringLiteralsConcatenationCheck (500 lines)
  */
 public final class TkInviteTest {
+
+    /**
+     * Netbout header identifyer.
+     */
+    private static final String NETBOUT_HEADER = "X-Netbout-Bout";
+
+    /**
+     * Netbout path for invitations.
+     */
+    private static final String INVITE_PATH = "/b/%d/invite";
 
     /**
      * TkInvite can invite user by email.
@@ -74,13 +82,13 @@ public final class TkInviteTest {
                         new RqFake(
                             RqMethod.POST,
                             String.format(
-                                "/b/%d/invite",
+                                INVITE_PATH,
                                 bout.number()
                             ),
                             "name=foo@bar.airforce"
                         )
                     ),
-                    "X-Netbout-Bout",
+                    NETBOUT_HEADER,
                     Long.toString(bout.number())
                 )
             );
@@ -100,7 +108,7 @@ public final class TkInviteTest {
     @Test (expected = RsFailure.class)
     public void failsWhenInvitingWithTooLongAlias() throws Exception {
         final MkBase base = new MkBase();
-        final String urn = "urn:test:1";
+        final String urn = "urn:test:2";
         final User user = base.user(new URN(urn));
         final String name = StringUtils.join(
             "12345678901234567890123456789012345678901234",
@@ -118,13 +126,13 @@ public final class TkInviteTest {
                         new RqFake(
                             RqMethod.POST,
                             String.format(
-                                "/b/%d/invite",
+                                INVITE_PATH,
                                 bout.number()
                             ),
                             String.format("name=%s", name)
                         )
                     ),
-                    "X-Netbout-Bout",
+                    NETBOUT_HEADER,
                     Long.toString(bout.number())
                 )
             );


### PR DESCRIPTION
added test for invite of too long alias and corrected TkInvite::act