### PR TITLE
 #986 quoted replacements

### DIFF
--- a/netbout-web/src/main/java/com/netbout/rest/MarkdownTxtmark.java
+++ b/netbout-web/src/main/java/com/netbout/rest/MarkdownTxtmark.java
@@ -27,7 +27,6 @@
 package com.netbout.rest;
 
 import com.github.rjeschke.txtmark.Processor;
-import com.jcabi.log.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import javax.validation.constraints.NotNull;
@@ -96,23 +95,15 @@ public final class MarkdownTxtmark implements Markdown {
         final Matcher matcher = MarkdownTxtmark.NEW_LINE.matcher(txt);
         while (matcher.find()) {
             if (!matcher.hitEnd()) {
-                try {
-                    matcher.appendReplacement(
-                        result,
-                        String.format(
-                            "%s  ", matcher.group()
-                        )
-                    );
-                } catch (final IndexOutOfBoundsException ex) {
-                    Logger.error(
-                        MarkdownTxtmark.class,
-                        "text %s causes %s", txt, ex.getMessage()
-                    );
-                }
+                matcher.appendReplacement(
+                    result,
+                    String.format(
+                        "%s  ", Matcher.quoteReplacement(matcher.group())
+                    )
+                );
             }
         }
         matcher.appendTail(result);
         return result.toString();
     }
-
 }

--- a/netbout-web/src/test/java/com/netbout/rest/MarkdownTxtmarkTest.java
+++ b/netbout-web/src/test/java/com/netbout/rest/MarkdownTxtmarkTest.java
@@ -291,4 +291,16 @@ public final class MarkdownTxtmarkTest {
             );
         }
     }
+
+    /**
+     * MarkdownTxtmark can escape the replacement string.
+     * @throws Exception If there is some problem inside
+     */
+    @Test
+    public void escapesReplacement() throws Exception {
+        MatcherAssert.assertThat(
+            new MarkdownTxtmark().html("backslash \\ and group reference $3\n"),
+            Matchers.is("<p>backslash \\ and group reference $3<br  /></p>\n")
+        );
+    }
 }


### PR DESCRIPTION
for #986

* fixed bug related to unquoted characters like `\` and `$` from Markdown input