### PR TITLE
Fix for #963 - Delete temporary files created by the H2Sql class

### DIFF
--- a/netbout-client/src/main/java/com/netbout/mock/H2Sql.java
+++ b/netbout-client/src/main/java/com/netbout/mock/H2Sql.java
@@ -63,6 +63,7 @@ final class H2Sql implements Sql {
         final File tmp = File.createTempFile("netbout-", ".h2");
         tmp.deleteOnExit();
         this.file = tmp.getAbsolutePath();
+        new File(String.format("%s.mv.db", this.file)).deleteOnExit();
         final String[] stmts = {
             // @checkstyle LineLength (5 lines)
             "CREATE TABLE alias (name VARCHAR, urn VARCHAR, photo VARCHAR, locale VARCHAR, email VARCHAR)",


### PR DESCRIPTION
Fix for #963 
- Marked the files created by the H2Sql class to be deleted on exit.