### PR TITLE
#997 ignored space after inline link

### DIFF
--- a/netbout-web/src/main/java/com/netbout/rest/MarkdownTxtmark.java
+++ b/netbout-web/src/main/java/com/netbout/rest/MarkdownTxtmark.java
@@ -45,7 +45,7 @@ public final class MarkdownTxtmark implements Markdown {
      */
     private static final Pattern LINK = Pattern.compile(
         // @checkstyle LineLengthCheck (1 line)
-        "(?<!\\]\\()(?<!\\]:\\s{0,256})(?<!=\")(https?:\\/\\/[a-zA-Z0-9-._~:\\?#@!$&'*+,;=%\\/]+[a-zA-Z0-9-_~#@$&'*+=%\\/])(?![\\w.]*\\]\\()"
+        "(?<!\\]\\s{0,256}\\()(?<!\\]:\\s{0,256})(?<!=\")(https?:\\/\\/[a-zA-Z0-9-._~:\\?#@!$&'*+,;=%\\/]+[a-zA-Z0-9-_~#@$&'*+=%\\/])(?![\\w.]*\\]\\()"
     );
     /**
      * Pattern to detect lines which should have a line break at the end.

--- a/netbout-web/src/test/java/com/netbout/rest/MarkdownTxtmarkTest.java
+++ b/netbout-web/src/test/java/com/netbout/rest/MarkdownTxtmarkTest.java
@@ -303,10 +303,12 @@ public final class MarkdownTxtmarkTest {
             },
             new String[] {
                 "![logo]  (http://img.qulice.com/logo.svg)",
+                // @checkstyle LineLengthCheck (1 line)
                 "<p><img src=\"http://img.qulice.com/logo.svg\" alt=\"logo\" /></p>",
             },
             new String[] {
                 "![logo](http://img.qulice.com/pict.svg)",
+                // @checkstyle LineLengthCheck (1 line)
                 "<p><img src=\"http://img.qulice.com/pict.svg\" alt=\"logo\" /></p>",
             },
         };

--- a/netbout-web/src/test/java/com/netbout/rest/MarkdownTxtmarkTest.java
+++ b/netbout-web/src/test/java/com/netbout/rest/MarkdownTxtmarkTest.java
@@ -301,6 +301,14 @@ public final class MarkdownTxtmarkTest {
                     "<a href=\"http://bar.com\">http://bar.com</a> <a href=\"http://af.com\">http://af.com</a> end</p>"
                 ),
             },
+            new String[] {
+                "![logo]  (http://img.qulice.com/logo.svg)",
+                "<p><img src=\"http://img.qulice.com/logo.svg\" alt=\"logo\" /></p>",
+            },
+            new String[] {
+                "![logo](http://img.qulice.com/pict.svg)",
+                "<p><img src=\"http://img.qulice.com/pict.svg\" alt=\"logo\" /></p>",
+            },
         };
         for (final String[] pair : texts) {
             MatcherAssert.assertThat(


### PR DESCRIPTION
for #997 

* fixed the html links detection regexp to ignore spaces after a inline link
* added unit tests
