### PR TITLE
#1023  fixed incorrect checking of a alias name

### DIFF
--- a/netbout-client/src/main/java/com/netbout/mock/MkBout.java
+++ b/netbout-client/src/main/java/com/netbout/mock/MkBout.java
@@ -48,6 +48,7 @@ import lombok.ToString;
  * @author Yegor Bugayenko (yegor@teamed.io)
  * @version $Id$
  * @since 2.4
+ * @checkstyle ClassDataAbstractionCouplingCheck (6 lines)
  */
 @Immutable
 @ToString
@@ -179,7 +180,7 @@ final class MkBout implements Bout {
 
     @Override
     public Friends friends() {
-        return new MkFriends(this.sql, this.bout);
+        return new Friends.ValidFriends(new MkFriends(this.sql, this.bout));
     }
 
     @Override

--- a/netbout-spi/src/main/java/com/netbout/spi/Friends.java
+++ b/netbout-spi/src/main/java/com/netbout/spi/Friends.java
@@ -30,6 +30,7 @@ import com.google.common.base.Predicate;
 import com.google.common.collect.Iterables;
 import com.jcabi.aspects.Immutable;
 import com.jcabi.aspects.Loggable;
+import com.jcabi.aspects.Tv;
 import java.io.IOException;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
@@ -42,6 +43,7 @@ import lombok.ToString;
  * @since 2.0
  */
 @Immutable
+@SuppressWarnings("PMD.TooManyMethods")
 public interface Friends {
 
     /**
@@ -150,4 +152,51 @@ public interface Friends {
         }
     }
 
+    /**
+     * Valid friends.
+     */
+    final class ValidFriends implements Friends {
+        /**
+         * Origin friends.
+         */
+        private final Friends origin;
+
+        /**
+         * Ctor.
+         * @param origin Origin Friends
+         */
+        public ValidFriends(final Friends origin) {
+            this.origin = origin;
+        }
+
+        @Override
+        public void invite(final String friend) throws IOException {
+            Friends.ValidFriends.validate(friend);
+            this.origin.invite(friend);
+        }
+
+        @Override
+        public void kick(final String friend) throws IOException {
+            Friends.ValidFriends.validate(friend);
+            this.origin.kick(friend);
+        }
+
+        @Override
+        public Iterable<Friend> iterate() throws IOException {
+            return this.origin.iterate();
+        }
+
+        /**
+         * Validate friend's name.
+         * @param name Name
+         */
+        private static void validate(final String name) {
+            if (name.trim().isEmpty()) {
+                throw new IllegalArgumentException("alias can't be empty");
+            }
+            if (name.length() > Tv.HUNDRED) {
+                throw new IllegalArgumentException("alias is too long");
+            }
+        }
+    }
 }

--- a/netbout-web/src/main/java/com/netbout/dynamo/DyBout.java
+++ b/netbout-web/src/main/java/com/netbout/dynamo/DyBout.java
@@ -177,7 +177,7 @@ final class DyBout implements Bout {
 
     @Override
     public Friends friends() {
-        return new DyFriends(this.region, this.item);
+        return new Friends.ValidFriends(new DyFriends(this.region, this.item));
     }
 
     @Override

--- a/netbout-web/src/main/java/com/netbout/rest/bout/TkInvite.java
+++ b/netbout-web/src/main/java/com/netbout/rest/bout/TkInvite.java
@@ -88,16 +88,11 @@ final class TkInvite implements Take {
         } else {
             guest = invite;
         }
-        final String check = new RqAlias(this.base, req)
-            .user().aliases().check(guest);
-        if (!check.isEmpty()) {
-            throw new RsFailure(
-                String.format("incorrect alias \"%s\", try again", guest)
-            );
-        }
         try {
             bout.friends().invite(guest);
-        } catch (final Friends.UnknownAliasException ex) {
+        } catch (
+            final Friends.UnknownAliasException | IllegalArgumentException ex
+        ) {
             throw new RsFailure(ex);
         }
         throw new RsForward(


### PR DESCRIPTION
for #1023 

* created a new `Friends` decorator `ValidFriends` that validates the alias name before using it
* moved the checking  form TkInvite to `DyFriends` and `MkFriends`
* created a new unit test