### PR TITLE
#992 Deployment failed due to the coverage report not exists

### DIFF
--- a/.rultor.yml
+++ b/.rultor.yml
@@ -74,7 +74,7 @@ release:
     git push -f heroku $(git symbolic-ref --short HEAD):master
     git reset HEAD~1
     curl -f --connect-timeout 15 --retry 5 --retry-delay 30 http://www.netbout.com
-    mvn  site-deploy -Psite --errors --settings ../settings.xml --batch-mode
+    mvn clean install site-deploy -Psite --errors --settings ../settings.xml --batch-mode
   commanders:
   - dmzaytsev
   - yegor256


### PR DESCRIPTION
For #992
  - Added clean install to the last command because just removing clean did not work. 