### PR TITLE
#998 turned missing page notice into severe type instead of success

### DIFF
--- a/netbout-web/src/main/java/com/netbout/rest/TkAppFallback.java
+++ b/netbout-web/src/main/java/com/netbout/rest/TkAppFallback.java
@@ -29,7 +29,9 @@ package com.netbout.rest;
 import com.jcabi.log.Logger;
 import com.jcabi.manifests.Manifests;
 import java.io.IOException;
+import java.io.UnsupportedEncodingException;
 import java.net.HttpURLConnection;
+import java.util.logging.Level;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.takes.Response;
 import org.takes.Take;
@@ -38,7 +40,8 @@ import org.takes.facets.fallback.FbChain;
 import org.takes.facets.fallback.FbStatus;
 import org.takes.facets.fallback.RqFallback;
 import org.takes.facets.fallback.TkFallback;
-import org.takes.facets.forward.RsFailure;
+import org.takes.facets.flash.RsFlash;
+import org.takes.facets.forward.RsForward;
 import org.takes.misc.Opt;
 import org.takes.rs.RsText;
 import org.takes.rs.RsVelocity;
@@ -64,9 +67,9 @@ final class TkAppFallback extends TkWrap {
     /**
      * Ctor.
      * @param take Take
-     * @throws IOException If fails
+     * @throws UnsupportedEncodingException If fails
      */
-    TkAppFallback(final Take take) throws IOException {
+    TkAppFallback(final Take take) throws UnsupportedEncodingException {
         super(TkAppFallback.make(take));
     }
 
@@ -74,15 +77,19 @@ final class TkAppFallback extends TkWrap {
      * Authenticated.
      * @param takes Take
      * @return Authenticated takes
-     * @throws IOException If fails
+     * @throws UnsupportedEncodingException If fails
      */
-    private static Take make(final Take takes) throws IOException {
+    private static Take make(final Take takes)
+        throws UnsupportedEncodingException {
         return new TkFallback(
             takes,
             new FbChain(
                 new FbStatus(
                     HttpURLConnection.HTTP_NOT_FOUND,
-                    new RsFailure("page not found")
+                    new RsForward(
+                        new RsFlash("page not found", Level.SEVERE),
+                        HttpURLConnection.HTTP_MOVED_PERM
+                    )
                 ),
                 new FbStatus(
                     HttpURLConnection.HTTP_BAD_REQUEST,

--- a/netbout-web/src/test/java/com/netbout/rest/TkAppITCase.java
+++ b/netbout-web/src/test/java/com/netbout/rest/TkAppITCase.java
@@ -33,6 +33,7 @@ import com.jcabi.manifests.Manifests;
 import java.net.HttpURLConnection;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
+import org.apache.commons.lang3.StringUtils;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Test;
@@ -55,6 +56,18 @@ public final class TkAppITCase {
      */
     private static final String DOCUMENTATION =
         Manifests.read("Netbout-Documentation");
+
+    /**
+     * Xpath to the 'page not found' notice.
+     */
+    private static final String MISSING =
+        StringUtils.join(
+            "/xhtml:html/xhtml:body/",
+            "xhtml:div[@class='content']/",
+            "xhtml:div[contains(@class, 'flash')",
+            " and contains(@class, 'SEVERE')",
+            " and text()[contains(., 'page not found')]]"
+        );
 
     /**
      * TkApp can render static resources.
@@ -80,7 +93,7 @@ public final class TkAppITCase {
     }
 
     /**
-     * TkApp can render non-found pages.
+     * TkApp can render non-found pages while adding a severe level notice.
      * @throws Exception If there is some problem inside
      */
     @Test
@@ -94,7 +107,11 @@ public final class TkAppITCase {
                 .uri().path(page).back()
                 .fetch()
                 .as(RestResponse.class)
-                .assertStatus(HttpURLConnection.HTTP_MOVED_PERM);
+                .assertStatus(HttpURLConnection.HTTP_MOVED_PERM)
+                .follow()
+                .fetch()
+                .as(XmlResponse.class)
+                .assertXPath(TkAppITCase.MISSING);
         }
     }
 

--- a/netbout-web/src/test/java/com/netbout/rest/TkAppITCase.java
+++ b/netbout-web/src/test/java/com/netbout/rest/TkAppITCase.java
@@ -58,18 +58,6 @@ public final class TkAppITCase {
         Manifests.read("Netbout-Documentation");
 
     /**
-     * Xpath to the 'page not found' notice.
-     */
-    private static final String MISSING =
-        StringUtils.join(
-            "/xhtml:html/xhtml:body/",
-            "xhtml:div[@class='content']/",
-            "xhtml:div[contains(@class, 'flash')",
-            " and contains(@class, 'SEVERE')",
-            " and text()[contains(., 'page not found')]]"
-        );
-
-    /**
      * TkApp can render static resources.
      * @throws Exception If there is some problem inside
      */
@@ -93,7 +81,7 @@ public final class TkAppITCase {
     }
 
     /**
-     * TkApp can render non-found pages while adding a severe level notice.
+     * TkApp can render missing pages and add flash message with level severe.
      * @throws Exception If there is some problem inside
      */
     @Test
@@ -111,7 +99,15 @@ public final class TkAppITCase {
                 .follow()
                 .fetch()
                 .as(XmlResponse.class)
-                .assertXPath(TkAppITCase.MISSING);
+                .assertXPath(
+                    StringUtils.join(
+                        "/xhtml:html/xhtml:body/",
+                        "xhtml:div[@class='content']/",
+                        "xhtml:div[contains(@class, 'flash')",
+                        " and contains(@class, 'SEVERE')",
+                        " and text()[contains(., 'page not found')]]"
+                    )
+                );
         }
     }
 


### PR DESCRIPTION
This solves #998 :
* Turned notice from success typo to severe type
 * Same logic used as in RsFailure, but adding the LEVEL.SEVERE to the RsFlash
 * Tightened up the exception type according to what this change allows
* Added checking the xPath, including of the class the red notice, to in the existing test for "404s"

Now looks like this:
![404](https://cloud.githubusercontent.com/assets/6490959/13190992/e7cb49fc-d760-11e5-8186-26add44121e5.png)
