### PR TITLE
#875 exception from kicking a non-existant user from a bout is properly handled

### DIFF
--- a/netbout-web/src/main/java/com/netbout/rest/bout/TkKick.java
+++ b/netbout-web/src/main/java/com/netbout/rest/bout/TkKick.java
@@ -29,6 +29,7 @@ package com.netbout.rest.bout;
 import com.netbout.spi.Attachments;
 import com.netbout.spi.Base;
 import com.netbout.spi.Bout;
+import com.netbout.spi.Friends;
 import java.io.IOException;
 import org.takes.Request;
 import org.takes.Response;
@@ -68,7 +69,10 @@ final class TkKick implements Take {
         final Bout bout = new RqBout(this.base, req).bout();
         try {
             bout.friends().kick(name);
-        } catch (final Attachments.InvalidNameException ex) {
+        } catch (
+            final Attachments.InvalidNameException
+            | Friends.UnknownAliasException ex
+        ) {
             throw new RsFailure(ex);
         }
         throw new RsForward(

--- a/netbout-web/src/test/java/com/netbout/rest/bout/TkBoutITCase.java
+++ b/netbout-web/src/test/java/com/netbout/rest/bout/TkBoutITCase.java
@@ -101,7 +101,7 @@ public final class TkBoutITCase {
     }
 
     /**
-     * TkBout can kick missing user and add flash message with level severe.
+     * TkBout can kick missing user and display severe level flash message.
      * @throws Exception If there is some problem inside
      */
     @Test
@@ -127,8 +127,8 @@ public final class TkBoutITCase {
                     "xhtml:div[contains(@class, 'flash')",
                     " and contains(@class, 'SEVERE')",
                     String.format(
-                        " and text()[contains(., \"alias '%s'"
-                        , name
+                        " and text()[contains(., \"alias '%s'",
+                        name
                     ),
                     " is not in the bout\")]]"
                 )

--- a/netbout-web/src/test/java/com/netbout/rest/bout/TkBoutITCase.java
+++ b/netbout-web/src/test/java/com/netbout/rest/bout/TkBoutITCase.java
@@ -28,6 +28,7 @@ package com.netbout.rest.bout;
 
 import com.jcabi.http.request.JdkRequest;
 import com.jcabi.http.response.RestResponse;
+import com.jcabi.http.response.XmlResponse;
 import com.netbout.client.RtUser;
 import com.netbout.spi.Alias;
 import com.netbout.spi.Attachment;
@@ -38,6 +39,7 @@ import java.net.HttpURLConnection;
 import java.net.URI;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.CharEncoding;
+import org.apache.commons.lang3.StringUtils;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Test;
@@ -98,4 +100,38 @@ public final class TkBoutITCase {
             .assertStatus(HttpURLConnection.HTTP_MOVED_PERM);
     }
 
+    /**
+     * TkBout can kick missing user and add flash message with level severe.
+     * @throws Exception If there is some problem inside
+     */
+    @Test
+    public void kicksNotFoundUser() throws Exception {
+        final User user = new RtUser(URI.create(TkBoutITCase.HOME), "");
+        final Alias alias = user.aliases().iterate().iterator().next();
+        final Bout bout = alias.inbox().bout(alias.inbox().start());
+        final String name = "invalid";
+        new JdkRequest(TkBoutITCase.HOME).uri()
+            .path(String.format("/b/%d/kick", bout.number()))
+            .queryParam("name", name)
+            .back()
+            .fetch()
+            .as(RestResponse.class)
+            .assertStatus(HttpURLConnection.HTTP_MOVED_PERM)
+            .follow()
+            .fetch()
+            .as(XmlResponse.class)
+            .assertXPath(
+                StringUtils.join(
+                    "/xhtml:html/xhtml:body/",
+                    "xhtml:div[@class='content']/",
+                    "xhtml:div[contains(@class, 'flash')",
+                    " and contains(@class, 'SEVERE')",
+                    String.format(
+                        " and text()[contains(., \"alias '%s'"
+                        , name
+                    ),
+                    " is not in the bout\")]]"
+                )
+            );
+    }
 }


### PR DESCRIPTION
This solves #875 

Fixed by:
* Handling the unknown `Friends.UnknownAliasException` where unknown attachment names are handled already
* Added integration test case

Now looks the way it should imo:
![noinbout](https://cloud.githubusercontent.com/assets/6490959/13203105/57db675a-d8af-11e5-9b2f-6e2ed6a18ddc.png)
