### PR TITLE
#850 Multiple tests do not work on Windows due to encoding set to 'windows-1250' by default 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -153,6 +153,7 @@
                     <artifactId>maven-surefire-plugin</artifactId>
                     <configuration>
                         <argLine>-Djava.awt.headless=true</argLine>
+                        <argLine>-Dfile.encoding=UTF-8</argLine>
                     </configuration>
                 </plugin>
                 <plugin>


### PR DESCRIPTION
For #850
 - Incorporated file encoding in the POM.