### PR TITLE
#1045: jmap configured

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
-web: cd netbout-web; java -Dfile.encoding=UTF-8 -Xmx512m -cp target/netbout.jar:target/deps/* com.netbout.Launch --port=${PORT} --threads=50 --max-latency=30000
+web: with_jmap java -Dfile.encoding=UTF-8 -Xmx512m -cp netbout-web/target/netbout.jar:netbout-web/target/deps/* com.netbout.Launch --port=${PORT} --threads=50 --max-latency=30000
 


### PR DESCRIPTION
see #1045 

This should turn JMAP dumps on. I configured S3 deployments already, as explained here: https://devcenter.heroku.com/articles/java-memory-issues#generating-heap-dumps-in-the-background