### PR TITLE
#851 local Netbout setup runs without requiring tests to be run beforehand

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ In case you are looking for an even quicker startup or experience failing tests,
 but still want to run the site, you can skip the tests by running:
 
 ```
-$ mvn clean install -DskipTests=true -Phit-refresh -Dport=8080
+$ mvn clean install -DskipTests -Phit-refresh -Dport=8080
 ```
 
 ### Integration tests

--- a/README.md
+++ b/README.md
@@ -81,6 +81,13 @@ $ mvn clean install -Phit-refresh -Dport=8080
 
 In a minute the site is ready at `http://localhost:8080`
 
+In case you are looking for an even quicker startup or experience failing tests,
+but still want to run the site, you can skip the tests by running:
+
+```
+$ mvn clean install -DskipTests=true -Phit-refresh -Dport=8080
+```
+
 ### Integration tests
 
 It is highly recommended to run integration tests to guarantee that your changes will not break any other part of the system.

--- a/netbout-web/pom.xml
+++ b/netbout-web/pom.xml
@@ -441,9 +441,9 @@
             </build>
         </profile>
         <profile>
-            <id>takes-test</id>
+            <id>takes-setup</id>
             <activation>
-                <property><name>!skipTests</name></property>
+                <file><exists>pom.xml</exists></file>
             </activation>
             <build>
                 <plugins>
@@ -480,21 +480,6 @@
                         </executions>
                     </plugin>
                     <plugin>
-                        <groupId>com.github.klieber</groupId>
-                        <artifactId>phantomjs-maven-plugin</artifactId>
-                        <version>0.4</version>
-                        <executions>
-                            <execution>
-                                <goals>
-                                    <goal>install</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                        <configuration>
-                            <version>1.9.2</version>
-                        </configuration>
-                    </plugin>
-                    <plugin>
                         <groupId>org.codehaus.mojo</groupId>
                         <artifactId>exec-maven-plugin</artifactId>
                         <version>1.3</version>
@@ -521,6 +506,40 @@
                                     </systemProperties>
                                 </configuration>
                             </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>casperjs</id>
+            <activation>
+                <property>
+                    <name>!skipTests</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>com.github.klieber</groupId>
+                        <artifactId>phantomjs-maven-plugin</artifactId>
+                        <version>0.4</version>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>install</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <version>1.9.2</version>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>exec-maven-plugin</artifactId>
+                        <version>1.3</version>
+                        <executions>
                             <execution>
                                 <id>casperjs-install</id>
                                 <phase>pre-integration-test</phase>
@@ -529,11 +548,14 @@
                                 </goals>
                                 <configuration>
                                     <executable>git</executable>
-                                    <workingDirectory>${project.build.directory}</workingDirectory>
+                                    <workingDirectory>${project.build.directory}
+                                    </workingDirectory>
                                     <arguments>
                                         <argument>clone</argument>
                                         <argument>--depth=1</argument>
-                                        <argument>https://github.com/n1k0/casperjs.git</argument>
+                                        <argument>
+                                            https://github.com/n1k0/casperjs.git
+                                        </argument>
                                         <argument>casperjs-install</argument>
                                     </arguments>
                                 </configuration>
@@ -552,19 +574,26 @@
                                     <goal>exec</goal>
                                 </goals>
                                 <configuration>
-                                    <executable>${casper.executable}</executable>
-                                    <workingDirectory>${basedir}</workingDirectory>
+                                    <executable>${casper.executable}
+                                    </executable>
+                                    <workingDirectory>${basedir}
+                                    </workingDirectory>
                                     <arguments>
                                         <argument>test</argument>
                                         <argument>--verbose</argument>
                                         <argument>--no-colors</argument>
                                         <argument>--concise</argument>
-                                        <argument>--home=http://localhost:${takes.port}</argument>
+                                        <argument>
+                                            --home=http://localhost:${takes.port}
+                                        </argument>
                                         <argument>--engine=phantomjs</argument>
-                                        <argument>${basedir}/src/test/casperjs</argument>
+                                        <argument>${basedir}/src/test/casperjs
+                                        </argument>
                                     </arguments>
                                     <environmentVariables>
-                                        <PHANTOMJS_EXECUTABLE>${phantomjs.binary}</PHANTOMJS_EXECUTABLE>
+                                        <PHANTOMJS_EXECUTABLE>
+                                            ${phantomjs.binary}
+                                        </PHANTOMJS_EXECUTABLE>
                                     </environmentVariables>
                                 </configuration>
                             </execution>
@@ -576,7 +605,7 @@
         <profile>
             <id>dynamodb</id>
             <activation>
-                <property><name>!skipTests</name></property>
+                <file><exists>pom.xml</exists></file>
             </activation>
             <build>
                 <plugins>

--- a/netbout-web/pom.xml
+++ b/netbout-web/pom.xml
@@ -548,14 +548,11 @@
                                 </goals>
                                 <configuration>
                                     <executable>git</executable>
-                                    <workingDirectory>${project.build.directory}
-                                    </workingDirectory>
+                                    <workingDirectory>${project.build.directory}</workingDirectory>
                                     <arguments>
                                         <argument>clone</argument>
                                         <argument>--depth=1</argument>
-                                        <argument>
-                                            https://github.com/n1k0/casperjs.git
-                                        </argument>
+                                        <argument>https://github.com/n1k0/casperjs.git</argument>
                                         <argument>casperjs-install</argument>
                                     </arguments>
                                 </configuration>
@@ -574,26 +571,19 @@
                                     <goal>exec</goal>
                                 </goals>
                                 <configuration>
-                                    <executable>${casper.executable}
-                                    </executable>
-                                    <workingDirectory>${basedir}
-                                    </workingDirectory>
+                                    <executable>${casper.executable}</executable>
+                                    <workingDirectory>${basedir}</workingDirectory>
                                     <arguments>
                                         <argument>test</argument>
                                         <argument>--verbose</argument>
                                         <argument>--no-colors</argument>
                                         <argument>--concise</argument>
-                                        <argument>
-                                            --home=http://localhost:${takes.port}
-                                        </argument>
+                                        <argument>--home=http://localhost:${takes.port}</argument>
                                         <argument>--engine=phantomjs</argument>
-                                        <argument>${basedir}/src/test/casperjs
-                                        </argument>
+                                        <argument>${basedir}/src/test/casperjs</argument>
                                     </arguments>
                                     <environmentVariables>
-                                        <PHANTOMJS_EXECUTABLE>
-                                            ${phantomjs.binary}
-                                        </PHANTOMJS_EXECUTABLE>
+                                        <PHANTOMJS_EXECUTABLE>${phantomjs.binary}</PHANTOMJS_EXECUTABLE>
                                     </environmentVariables>
                                 </configuration>
                             </execution>


### PR DESCRIPTION
#851 is resolved by this.

PR looks bigger than it is:
* Created new profile `casperjs` that does nto run when tests are skipped
* Moved all casperjs related things ( install and test run ) in there
* Made the requirements for local run via the `hit-refresh` profile load per default
 * I think this is ok now, given that we only load the things for local run, not the casperjs install since I moved it out of the takes-test block
* Renamed profile `takes-test` to `takes-setup` since this does not invoke the casperjs tests like it did before anymore now