### PR TITLE
#1069: upgrade github maven plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -166,6 +166,11 @@
                             <timestampFormat>yyyy-MM-dd'T'HH:mm:ss</timestampFormat>
                         </configuration>
                 </plugin>
+                <plugin>
+                    <groupId>com.github.github</groupId>
+                    <artifactId>site-maven-plugin</artifactId>
+                    <version>0.12</version>
+                </plugin>
             </plugins>
         </pluginManagement>
     </build>
@@ -180,7 +185,6 @@
                     <plugin>
                         <groupId>org.codehaus.mojo</groupId>
                         <artifactId>cobertura-maven-plugin</artifactId>
-                        <version>2.7</version>
                         <executions>
                             <execution>
                                 <phase>pre-site</phase>


### PR DESCRIPTION
#1069: updated com.github.github:site-maven-plugin version  to 0.12, downgraded cobertura version  to 2.6 (#1065 [comment](https://github.com/yegor256/netbout/pull/1065#issuecomment-191423258))