### PR TITLE
#952 - Fixed preview for code blocks marked with ```

### DIFF
--- a/netbout-web/src/main/java/com/netbout/rest/MarkdownTxtmark.java
+++ b/netbout-web/src/main/java/com/netbout/rest/MarkdownTxtmark.java
@@ -60,14 +60,6 @@ public final class MarkdownTxtmark implements Markdown {
     private static final Pattern NEW_LINE = Pattern.compile(
         "^ {0,3}(\\S|(\\S.*\\S)) ?$", Pattern.MULTILINE
     );
-    /**
-     * Html &lt;pre&gt;&ltcode&gt; fragment.
-     */
-    private static final String PRE_CODE = "<pre><code>";
-    /**
-     * Html &lt;/code&gt;&lt/end&gt; fragment.
-     */
-    private static final String END_CODE_PRE = "</code></pre>";
 
     @Override
     public String html(@NotNull final String txt) {
@@ -77,7 +69,7 @@ public final class MarkdownTxtmark implements Markdown {
         return MarkdownTxtmark.fixedCodeBlocks(
             Processor.process(
                 MarkdownTxtmark.formatLinks(
-                    MarkdownTxtmark.makeLineBreakMarkedCode(
+                    MarkdownTxtmark.makeLineBreakExcludeCode(
                         txt,
                         Arrays.asList("```", "``", "`").iterator()
                     )
@@ -115,7 +107,7 @@ public final class MarkdownTxtmark implements Markdown {
      * @param markers Markers to be used in the iteration order
      * @return Text with Markdown-formatted line breaks outside code blocks
      */
-    private static String makeLineBreakMarkedCode(final String txt,
+    private static String makeLineBreakExcludeCode(final String txt,
         final Iterator<String> markers) {
         final String result;
         if (markers.hasNext()) {
@@ -128,7 +120,7 @@ public final class MarkdownTxtmark implements Markdown {
                     .append(fragment)
                         .append(marker);
                 } else {
-                    builder.append(makeLineBreakMarkedCode(fragment, markers));
+                    builder.append(makeLineBreakExcludeCode(fragment, markers));
                 }
                 code = !code;
             }
@@ -169,11 +161,7 @@ public final class MarkdownTxtmark implements Markdown {
      */
     private static String fixedCodeBlocks(final String txt) {
         return txt
-            .replace("<code>`\r\n", MarkdownTxtmark.PRE_CODE)
-            .replace("<code>`\n", MarkdownTxtmark.PRE_CODE)
-            .replace("<code>`", MarkdownTxtmark.PRE_CODE)
-            .replace("\r\n</code>`", MarkdownTxtmark.END_CODE_PRE)
-            .replace("\n</code>`", MarkdownTxtmark.END_CODE_PRE)
-            .replace("</code>`", MarkdownTxtmark.END_CODE_PRE);
+            .replaceAll("<code>`\\R?", "<pre><code>")
+            .replaceAll("\\R?</code>`", "</code></pre>");
     }
 }

--- a/netbout-web/src/main/java/com/netbout/rest/MarkdownTxtmark.java
+++ b/netbout-web/src/main/java/com/netbout/rest/MarkdownTxtmark.java
@@ -60,6 +60,23 @@ public final class MarkdownTxtmark implements Markdown {
     private static final Pattern NEW_LINE = Pattern.compile(
         "^ {0,3}(\\S|(\\S.*\\S)) ?$", Pattern.MULTILINE
     );
+    /**
+     * String pattern for end of line characters match.
+     * @checkstyle LineLengthCheck (2 line)
+     */
+    private static final String EOL = "\\u000D\\u000A|[\\u000A\\u000B\\u000C\\u000D\\u0085\\u2028\\u2029]";
+    /**
+     * Pattern used for fixing the start of code blocks after processing.
+     */
+    private static final Pattern CODE_BLOCK_START = Pattern.compile(
+        String.format("<code>`(%s)?", MarkdownTxtmark.EOL)
+    );
+    /**
+     * Pattern used for fixing the end of code blocks after processing.
+     */
+    private static final Pattern CODE_BLOCK_END = Pattern.compile(
+        String.format("(%s)?</code>`", MarkdownTxtmark.EOL)
+    );
 
     @Override
     public String html(@NotNull final String txt) {
@@ -160,15 +177,10 @@ public final class MarkdownTxtmark implements Markdown {
      * @return Fixed text with correct code blocks.
      */
     private static String fixedCodeBlocks(final String txt) {
-        // @checkstyle LineLengthCheck (1 line)
-        final String eol = "\\u000D\\u000A|[\\u000A\\u000B\\u000C\\u000D\\u0085\\u2028\\u2029]";
-        return txt
-            .replaceAll(
-                String.format("<code>`(%s)?", eol),
-                "<pre><code>"
-            ).replaceAll(
-                String.format("(%s)?</code>`", eol),
-                "</code></pre>"
-            );
+        return MarkdownTxtmark.CODE_BLOCK_END.matcher(
+            MarkdownTxtmark.CODE_BLOCK_START
+            .matcher(txt)
+            .replaceAll("<pre><code>")
+        ).replaceAll("</code></pre>");
     }
 }

--- a/netbout-web/src/main/java/com/netbout/rest/MarkdownTxtmark.java
+++ b/netbout-web/src/main/java/com/netbout/rest/MarkdownTxtmark.java
@@ -160,8 +160,15 @@ public final class MarkdownTxtmark implements Markdown {
      * @return Fixed text with correct code blocks.
      */
     private static String fixedCodeBlocks(final String txt) {
+        // @checkstyle LineLengthCheck (1 line)
+        final String eol = "\\u000D\\u000A|[\\u000A\\u000B\\u000C\\u000D\\u0085\\u2028\\u2029]";
         return txt
-            .replaceAll("<code>`\\R?", "<pre><code>")
-            .replaceAll("\\R?</code>`", "</code></pre>");
+            .replaceAll(
+                String.format("<code>`(%s)?", eol),
+                "<pre><code>"
+            ).replaceAll(
+                String.format("(%s)?</code>`", eol),
+                "</code></pre>"
+            );
     }
 }

--- a/netbout-web/src/test/java/com/netbout/rest/MarkdownTxtmarkTest.java
+++ b/netbout-web/src/test/java/com/netbout/rest/MarkdownTxtmarkTest.java
@@ -39,7 +39,9 @@ import org.junit.Test;
  * @version $Id$
  * @since 2.23
  */
-@SuppressWarnings("PMD.TooManyMethods")
+@SuppressWarnings(
+    {"PMD.TooManyMethods", "PMD.AvoidInstantiatingObjectsInLoops"}
+)
 public final class MarkdownTxtmarkTest {
     /**
      * End of line.
@@ -100,7 +102,6 @@ public final class MarkdownTxtmarkTest {
      * @throws Exception If there is some problem inside
      */
     @Test
-    @SuppressWarnings("PMD.AvoidInstantiatingObjectsInLoops")
     public void handlesBrokenFormattingGracefully() throws Exception {
         final String[] texts = {
             Joiner.on(MarkdownTxtmarkTest.EOL).join("**", ""),
@@ -162,7 +163,6 @@ public final class MarkdownTxtmarkTest {
      * @throws Exception If there is some problem inside
      */
     @Test
-    @SuppressWarnings("PMD.AvoidInstantiatingObjectsInLoops")
     public void formatsTextFragmentsToHtml() throws Exception {
         final String[][] texts = {
             new String[] {"hi, *dude*!", "<p>hi, <em>dude</em>!</p>"},
@@ -187,6 +187,27 @@ public final class MarkdownTxtmarkTest {
                 "<p><a href=\"http://foo\">a</a></p>",
             },
             new String[] {"}}}", "<p>}}}</p>"},
+        };
+        for (final String[] pair : texts) {
+            MatcherAssert.assertThat(
+                new MarkdownTxtmark().html(pair[0]).trim(),
+                Matchers.equalTo(pair[1])
+            );
+        }
+    }
+
+    /**
+     * MarkdownTxmart can format code blocks to HTML.
+     * Must be <pre><code>content</code></pre>
+     * @throws Exception If there are some problems inside.
+     */
+    @Test
+    public void formatsCodeBlocksToHtml() throws Exception {
+        final String[][] texts = {
+            new String[] {
+                "```\ncode\nanother line of code\n```",
+                "<p><pre><code>code\nanother line of code</code></pre></p>",
+            },
         };
         for (final String[] pair : texts) {
             MatcherAssert.assertThat(
@@ -267,7 +288,6 @@ public final class MarkdownTxtmarkTest {
      * @throws Exception If there is some problem inside
      */
     @Test
-    @SuppressWarnings("PMD.AvoidInstantiatingObjectsInLoops")
     public void detectsLinks() throws Exception {
         final String[][] texts = {
             new String[] {

--- a/netbout-web/src/test/java/com/netbout/rest/MarkdownTxtmarkTest.java
+++ b/netbout-web/src/test/java/com/netbout/rest/MarkdownTxtmarkTest.java
@@ -197,16 +197,25 @@ public final class MarkdownTxtmarkTest {
     }
 
     /**
-     * MarkdownTxmart can format code blocks to HTML.
-     * Must be <pre><code>content</code></pre>
+     * MarkdownTxmart can format code fragments (blocks and spans) to HTML.
+     * Must be <pre><code>content_without_surrounding_eols</code></pre> for
+     * blocks and <code>content</code> for spans.
      * @throws Exception If there are some problems inside.
      */
     @Test
-    public void formatsCodeBlocksToHtml() throws Exception {
+    public void formatsCodeFragmentsToHtml() throws Exception {
         final String[][] texts = {
             new String[] {
                 "```\ncode\nanother line of code\n```",
                 "<p><pre><code>code\nanother line of code</code></pre></p>",
+            },
+            new String[] {
+                "``code span not block\nextra line``",
+                "<p><code>code span not block\nextra line</code></p>",
+            },
+            new String[] {
+                "`single char\nextra line with eol\n`",
+                "<p><code>single char\nextra line with eol\n</code></p>",
             },
         };
         for (final String[] pair : texts) {


### PR DESCRIPTION
#952 - Fixed preview for code blocks.
- Updated MarkdownTxtmark to iterate through input text and add trailing spaces (for line breaks) only for fragments outside code blocks to avoid invalid br elements;
- Updated MarkdownTxtmark class with methods for inserting html pre elements where needed to display line breaks in code fragments;
- Added test method to MarkdownTxtmark for testing code blocks.