### PR TITLE
#839 Added author() and date() to Attachment and implementations.

### DIFF
--- a/netbout-client/src/main/java/com/netbout/client/RtAttachment.java
+++ b/netbout-client/src/main/java/com/netbout/client/RtAttachment.java
@@ -117,8 +117,6 @@ final class RtAttachment implements Attachment {
         );
     }
 
-    // There is a puzzle about this method in
-    // DyAttachmentITCase.obtainsCreationDate()
     @Override
     public Date date() throws IOException {
         return new Date();

--- a/netbout-client/src/main/java/com/netbout/client/RtAttachment.java
+++ b/netbout-client/src/main/java/com/netbout/client/RtAttachment.java
@@ -37,6 +37,7 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.HttpURLConnection;
+import java.util.Date;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
 import lombok.EqualsAndHashCode;
@@ -114,6 +115,24 @@ final class RtAttachment implements Attachment {
                 .xpath(this.xpath("unseen/text()"))
                 .get(0)
         );
+    }
+
+    // There is a puzzle about this method in
+    // DyAttachmentITCase.obtainsCreationDate()
+    @Override
+    public Date date() throws IOException {
+        return new Date();
+    }
+
+    @Override
+    public String author() throws IOException {
+        return this.request.fetch()
+            .as(RestResponse.class)
+            .assertStatus(HttpURLConnection.HTTP_OK)
+            .as(XmlResponse.class)
+            .xml()
+            .xpath(this.xpath("author/text()"))
+            .get(0);
     }
 
     @Override

--- a/netbout-client/src/main/java/com/netbout/client/cached/CdAttachment.java
+++ b/netbout-client/src/main/java/com/netbout/client/cached/CdAttachment.java
@@ -32,6 +32,7 @@ import com.jcabi.aspects.Loggable;
 import com.netbout.spi.Attachment;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Date;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -83,6 +84,18 @@ public final class CdAttachment implements Attachment {
     @Cacheable
     public boolean unseen() throws IOException {
         return this.origin.unseen();
+    }
+
+    @Override
+    @Cacheable
+    public Date date() throws IOException {
+        return this.origin.date();
+    }
+
+    @Override
+    @Cacheable
+    public String author() throws IOException {
+        return this.origin.author();
     }
 
     @Override

--- a/netbout-client/src/main/java/com/netbout/client/retry/ReAttachment.java
+++ b/netbout-client/src/main/java/com/netbout/client/retry/ReAttachment.java
@@ -34,6 +34,7 @@ import com.netbout.spi.Attachment;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Date;
 import java.util.concurrent.TimeUnit;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
@@ -99,6 +100,24 @@ public final class ReAttachment implements Attachment {
     )
     public boolean unseen() throws IOException {
         return this.origin.unseen();
+    }
+
+    @Override
+    @RetryOnFailure(
+        verbose = false, attempts = Tv.TWENTY,
+        delay = Tv.FIVE, unit = TimeUnit.SECONDS
+    )
+    public Date date() throws IOException {
+        return this.origin.date();
+    }
+
+    @Override
+    @RetryOnFailure(
+        verbose = false, attempts = Tv.TWENTY,
+        delay = Tv.FIVE, unit = TimeUnit.SECONDS
+    )
+    public String author() throws IOException {
+        return this.origin.author();
     }
 
     @Override

--- a/netbout-client/src/main/java/com/netbout/mock/H2Sql.java
+++ b/netbout-client/src/main/java/com/netbout/mock/H2Sql.java
@@ -83,7 +83,7 @@ final class H2Sql implements Sql {
             "CREATE TABLE alias (name VARCHAR, urn VARCHAR, photo VARCHAR, locale VARCHAR, email VARCHAR)",
             "CREATE TABLE bout (number BIGINT AUTO_INCREMENT, title VARCHAR, date TIMESTAMP DEFAULT CURRENT_TIMESTAMP, updated TIMESTAMP DEFAULT CURRENT_TIMESTAMP)",
             "CREATE TABLE message (number BIGINT AUTO_INCREMENT, bout BIGINT, text VARCHAR, author VARCHAR, date TIMESTAMP DEFAULT CURRENT_TIMESTAMP)",
-            "CREATE TABLE attachment (name VARCHAR, bout BIGINT, data VARCHAR, author VARCHAR, ctype VARCHAR, etag VARCHAR)",
+            "CREATE TABLE attachment (name VARCHAR, bout BIGINT, data VARCHAR, author VARCHAR, ctype VARCHAR, etag VARCHAR, date TIMESTAMP DEFAULT CURRENT_TIMESTAMP)",
             "CREATE TABLE friend (alias VARCHAR, bout BIGINT, subscription INTEGER )",
         };
         final JdbcSession session = new JdbcSession(H2Sql.source(result));

--- a/netbout-client/src/main/java/com/netbout/mock/MkAttachment.java
+++ b/netbout-client/src/main/java/com/netbout/mock/MkAttachment.java
@@ -129,17 +129,18 @@ final class MkAttachment implements Attachment {
                 .select(
                     new Outcome<Date>() {
                         @Override
-                        public Date handle(
-                            final ResultSet rset,
-                            final Statement stmt
-                        ) throws SQLException {
+                        public Date handle(final ResultSet rset,
+                            final Statement stmt) throws SQLException {
                             rset.next();
                             return new Date(rset.getTimestamp(1).getTime());
                         }
                     }
                 );
         } catch (final SQLException ex) {
-            throw new IOException(ex);
+            throw new IOException(
+                String.format("Can't fetch date from bout #%d", this.bout),
+                ex
+            );
         }
     }
 
@@ -147,13 +148,17 @@ final class MkAttachment implements Attachment {
     public String author() throws IOException {
         try {
             return new JdbcSession(this.sql.source())
-                // @checkstyle LineLength (1 line)
-                .sql("SELECT author FROM attachment WHERE bout = ? AND name = ?")
+                .sql(
+                    "SELECT author FROM attachment WHERE bout = ? AND name = ?"
+                )
                 .set(this.bout)
                 .set(this.label)
                 .select(new SingleOutcome<>(String.class));
         } catch (final SQLException ex) {
-            throw new IOException(ex);
+            throw new IOException(
+                String.format("Can't fetch author from bout #%d", this.bout),
+                ex
+            );
         }
     }
 

--- a/netbout-client/src/test/java/com/netbout/client/RtAttachmentsITCase.java
+++ b/netbout-client/src/test/java/com/netbout/client/RtAttachmentsITCase.java
@@ -113,11 +113,10 @@ public final class RtAttachmentsITCase {
     @Ignore
     @Test
     public void obtainsCreationDate() throws Exception {
-        final User user = NbRule.get();
-        final Alias alias = user.aliases().iterate().iterator().next();
+        final Alias alias = NbRule.get().aliases().iterate().iterator().next();
         final Inbox inbox = alias.inbox();
-        final Bout bout = inbox.bout(inbox.start());
-        final Attachments attachments = bout.attachments();
+        final Attachments attachments =
+            inbox.bout(inbox.start()).attachments();
         final long before = System.currentTimeMillis();
         final String name = "attach-name";
         attachments.create(name);

--- a/netbout-client/src/test/java/com/netbout/client/RtAttachmentsITCase.java
+++ b/netbout-client/src/test/java/com/netbout/client/RtAttachmentsITCase.java
@@ -122,11 +122,11 @@ public final class RtAttachmentsITCase {
         attachments.create(name);
         final Attachment attachment = attachments.get(name);
         MatcherAssert.assertThat(
-            attachment.date().getTime(), Matchers.greaterThan(before)
+            attachment.date().getTime(), Matchers.greaterThanOrEqualTo(before)
         );
         final long after = System.currentTimeMillis();
         MatcherAssert.assertThat(
-            attachment.date().getTime(), Matchers.lessThan(after)
+            attachment.date().getTime(), Matchers.lessThanOrEqualTo(after)
         );
         attachments.delete(name);
     }

--- a/netbout-client/src/test/java/com/netbout/client/RtAttachmentsITCase.java
+++ b/netbout-client/src/test/java/com/netbout/client/RtAttachmentsITCase.java
@@ -36,6 +36,7 @@ import java.io.ByteArrayInputStream;
 import org.apache.commons.io.IOUtils;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -81,6 +82,52 @@ public final class RtAttachmentsITCase {
         MatcherAssert.assertThat(
             IOUtils.toByteArray(attachment.read()),
             Matchers.equalTo(data)
+        );
+        attachments.delete(name);
+    }
+
+    /**
+     * RtAttachments can obtain author of an attachment.
+     * @throws Exception If there is some problem inside
+     */
+    @Test
+    public void obtainsAuthor() throws Exception {
+        final User user = NbRule.get();
+        final Alias alias = user.aliases().iterate().iterator().next();
+        final Inbox inbox = alias.inbox();
+        final Bout bout = inbox.bout(inbox.start());
+        final Attachments attachments = bout.attachments();
+        final String name = "name";
+        attachments.create(name);
+        final Attachment attachment = attachments.get(name);
+        MatcherAssert.assertThat(
+            attachment.author(), Matchers.equalTo(alias.name())
+        );
+        attachments.delete(name);
+    }
+
+    /**
+     * RtAttachments can obtain the creation date of an attachment.
+     * @throws Exception If there is some problem inside
+     */
+    @Ignore
+    @Test
+    public void obtainsCreationDate() throws Exception {
+        final User user = NbRule.get();
+        final Alias alias = user.aliases().iterate().iterator().next();
+        final Inbox inbox = alias.inbox();
+        final Bout bout = inbox.bout(inbox.start());
+        final Attachments attachments = bout.attachments();
+        final long before = System.currentTimeMillis();
+        final String name = "attach-name";
+        attachments.create(name);
+        final Attachment attachment = attachments.get(name);
+        MatcherAssert.assertThat(
+            attachment.date().getTime(), Matchers.greaterThan(before)
+        );
+        final long after = System.currentTimeMillis();
+        MatcherAssert.assertThat(
+            attachment.date().getTime(), Matchers.lessThan(after)
         );
         attachments.delete(name);
     }

--- a/netbout-client/src/test/java/com/netbout/client/RtAttachmentsITCase.java
+++ b/netbout-client/src/test/java/com/netbout/client/RtAttachmentsITCase.java
@@ -95,8 +95,8 @@ public final class RtAttachmentsITCase {
         final User user = NbRule.get();
         final Alias alias = user.aliases().iterate().iterator().next();
         final Inbox inbox = alias.inbox();
-        final Bout bout = inbox.bout(inbox.start());
-        final Attachments attachments = bout.attachments();
+        final Attachments attachments = inbox.bout(inbox.start())
+            .attachments();
         final String name = "name";
         attachments.create(name);
         final Attachment attachment = attachments.get(name);

--- a/netbout-client/src/test/java/com/netbout/mock/MkAttachmentsTest.java
+++ b/netbout-client/src/test/java/com/netbout/mock/MkAttachmentsTest.java
@@ -27,9 +27,11 @@
 package com.netbout.mock;
 
 import com.jcabi.aspects.Tv;
+import com.netbout.spi.Alias;
 import com.netbout.spi.Attachment;
 import com.netbout.spi.Attachments;
 import com.netbout.spi.Bout;
+import com.netbout.spi.Inbox;
 import java.nio.charset.StandardCharsets;
 import org.apache.commons.io.IOUtils;
 import org.hamcrest.MatcherAssert;
@@ -90,6 +92,45 @@ public final class MkAttachmentsTest {
         Thread.sleep(Tv.HUNDRED);
         MatcherAssert.assertThat(
             bout.updated().getTime(), Matchers.greaterThan(last)
+        );
+    }
+
+    /**
+     * MkAttachments can obtain the author of an attachment.
+     * @throws Exception If there is some problem inside
+     */
+    @Test
+    public void obtainsAuthor() throws Exception {
+        final Alias alias = new MkBase().randomAlias();
+        final Inbox inbox = alias.inbox();
+        final Bout bout = inbox.bout(inbox.start());
+        final Attachments attachments = bout.attachments();
+        final String name = "name";
+        attachments.create(name);
+        final Attachment attachment = attachments.get(name);
+        MatcherAssert.assertThat(
+            attachment.author(), Matchers.equalTo(alias.name())
+        );
+    }
+
+    /**
+     * MkAttachments can obtain the creation date of an attachment.
+     * @throws Exception If there is some problem inside
+     */
+    @Test
+    public void obtainsCreationDate() throws Exception {
+        final Bout bout = new MkBase().randomBout();
+        final Attachments attachments = bout.attachments();
+        final long before = System.currentTimeMillis();
+        final String name = "attach-name";
+        attachments.create(name);
+        final Attachment attachment = attachments.get(name);
+        MatcherAssert.assertThat(
+            attachment.date().getTime(), Matchers.greaterThan(before)
+        );
+        final long after = System.currentTimeMillis();
+        MatcherAssert.assertThat(
+            attachment.date().getTime(), Matchers.lessThan(after)
         );
     }
 }

--- a/netbout-client/src/test/java/com/netbout/mock/MkAttachmentsTest.java
+++ b/netbout-client/src/test/java/com/netbout/mock/MkAttachmentsTest.java
@@ -126,11 +126,11 @@ public final class MkAttachmentsTest {
         attachments.create(name);
         final Attachment attachment = attachments.get(name);
         MatcherAssert.assertThat(
-            attachment.date().getTime(), Matchers.greaterThan(before)
+            attachment.date().getTime(), Matchers.greaterThanOrEqualTo(before)
         );
         final long after = System.currentTimeMillis();
         MatcherAssert.assertThat(
-            attachment.date().getTime(), Matchers.lessThan(after)
+            attachment.date().getTime(), Matchers.lessThanOrEqualTo(after)
         );
     }
 }

--- a/netbout-client/src/test/java/com/netbout/mock/MkAttachmentsTest.java
+++ b/netbout-client/src/test/java/com/netbout/mock/MkAttachmentsTest.java
@@ -103,8 +103,8 @@ public final class MkAttachmentsTest {
     public void obtainsAuthor() throws Exception {
         final Alias alias = new MkBase().randomAlias();
         final Inbox inbox = alias.inbox();
-        final Bout bout = inbox.bout(inbox.start());
-        final Attachments attachments = bout.attachments();
+        final Attachments attachments = inbox.bout(inbox.start())
+            .attachments();
         final String name = "name";
         attachments.create(name);
         final Attachment attachment = attachments.get(name);

--- a/netbout-spi/src/main/java/com/netbout/spi/Attachment.java
+++ b/netbout-spi/src/main/java/com/netbout/spi/Attachment.java
@@ -29,6 +29,7 @@ package com.netbout.spi;
 import com.jcabi.aspects.Immutable;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Date;
 
 /**
  * Attachment.
@@ -72,6 +73,20 @@ public interface Attachment {
      * @throws IOException If fails
      */
     boolean unseen() throws IOException;
+
+    /**
+     * When it was created.
+     * @return The date of creation
+     * @throws IOException If fails
+     */
+    Date date() throws IOException;
+
+    /**
+     * Author of it.
+     * @return The author
+     * @throws IOException If fails
+     */
+    String author() throws IOException;
 
     /**
      * Read content.

--- a/netbout-web/src/main/java/com/netbout/cached/CdAttachment.java
+++ b/netbout-web/src/main/java/com/netbout/cached/CdAttachment.java
@@ -33,6 +33,7 @@ import com.jcabi.aspects.Tv;
 import com.netbout.spi.Attachment;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Date;
 import java.util.concurrent.TimeUnit;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
@@ -85,6 +86,18 @@ final class CdAttachment implements Attachment {
     @Cacheable(lifetime = Tv.FIVE, unit = TimeUnit.HOURS)
     public boolean unseen() throws IOException {
         return this.origin.unseen();
+    }
+
+    @Override
+    @Cacheable(lifetime = Tv.FIVE, unit = TimeUnit.HOURS)
+    public Date date() throws IOException {
+        return this.origin.date();
+    }
+
+    @Override
+    @Cacheable(lifetime = Tv.FIVE, unit = TimeUnit.HOURS)
+    public String author() throws IOException {
+        return this.origin.author();
     }
 
     @Override

--- a/netbout-web/src/main/java/com/netbout/dynamo/DyAttachment.java
+++ b/netbout-web/src/main/java/com/netbout/dynamo/DyAttachment.java
@@ -163,6 +163,13 @@ final class DyAttachment implements Attachment {
             && itm.get(DyFriends.ATTR_UNSEEN).getSS().contains(this.name());
     }
 
+    // @todo #839:30min Attachment Item in remote db must have an
+    //  attribute for the creation time added. Until then, this method crashes.
+    //  Once it is done, this must be developed:
+    //  - Remove @Ignore from DyAttachmentITCase.obtainsCreationDate().
+    //  - Add directive for date in XeAttachment.make().
+    //  - Properly implement RtAttachment.date() to retrieve date from request.
+    //  - Remove @Ignore from RtAttachmentsITCase.obtainsCreationDate().
     @Override
     public Date date() throws IOException {
         return new Date(

--- a/netbout-web/src/main/java/com/netbout/dynamo/DyAttachment.java
+++ b/netbout-web/src/main/java/com/netbout/dynamo/DyAttachment.java
@@ -163,8 +163,8 @@ final class DyAttachment implements Attachment {
             && itm.get(DyFriends.ATTR_UNSEEN).getSS().contains(this.name());
     }
 
-    // @todo #839:30min Attachment Item in remote db must have an
-    //  attribute for the creation time added. Until then, this method crashes.
+    // @todo #839:30min An attribute for the creation time must be added to the
+    //  attachment item in the remote db. Until then, this method crashes.
     //  Once it is done, this must be developed:
     //  - Remove @Ignore from DyAttachmentITCase.obtainsCreationDate().
     //  - Add directive for date in XeAttachment.make().

--- a/netbout-web/src/main/java/com/netbout/dynamo/DyAttachment.java
+++ b/netbout-web/src/main/java/com/netbout/dynamo/DyAttachment.java
@@ -52,6 +52,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
+import java.util.Date;
 import java.util.HashSet;
 import java.util.Set;
 import lombok.EqualsAndHashCode;
@@ -160,6 +161,20 @@ final class DyAttachment implements Attachment {
             .iterator().next();
         return itm.has(DyFriends.ATTR_UNSEEN)
             && itm.get(DyFriends.ATTR_UNSEEN).getSS().contains(this.name());
+    }
+
+    @Override
+    public Date date() throws IOException {
+        return new Date(
+            Long.parseLong(
+                this.item.get(DyFriends.ATTR_UPDATED).getN()
+            )
+        );
+    }
+
+    @Override
+    public String author() throws IOException {
+        return this.item.get(DyAttachments.ATTR_ALIAS).getS();
     }
 
     @Override

--- a/netbout-web/src/main/java/com/netbout/email/EmAttachment.java
+++ b/netbout-web/src/main/java/com/netbout/email/EmAttachment.java
@@ -31,6 +31,7 @@ import com.jcabi.aspects.Loggable;
 import com.netbout.spi.Attachment;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Date;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -78,6 +79,16 @@ final class EmAttachment implements Attachment {
     @Override
     public boolean unseen() throws IOException {
         return this.origin.unseen();
+    }
+
+    @Override
+    public Date date() throws IOException {
+        return this.origin.date();
+    }
+
+    @Override
+    public String author() throws IOException {
+        return this.origin.author();
     }
 
     @Override

--- a/netbout-web/src/main/java/com/netbout/rest/bout/XeAttachment.java
+++ b/netbout-web/src/main/java/com/netbout/rest/bout/XeAttachment.java
@@ -93,7 +93,8 @@ final class XeAttachment extends XeWrap {
                     .add("name").set(atmt.name()).up()
                     .add("ctype").set(atmt.ctype()).up()
                     .add("etag").set(atmt.etag()).up()
-                    .add("unseen").set(Boolean.toString(atmt.unseen()))
+                    .add("unseen").set(Boolean.toString(atmt.unseen())).up()
+                    .add("author").set(atmt.author())
             ),
             new XeLink(
                 "delete",

--- a/netbout-web/src/test/java/com/netbout/dynamo/DyAttachmentITCase.java
+++ b/netbout-web/src/test/java/com/netbout/dynamo/DyAttachmentITCase.java
@@ -125,11 +125,11 @@ public final class DyAttachmentITCase {
         attachments.create(name);
         final Attachment attachment = attachments.get(name);
         MatcherAssert.assertThat(
-            attachment.date().getTime(), Matchers.greaterThan(before)
+            attachment.date().getTime(), Matchers.greaterThanOrEqualTo(before)
         );
         final long after = System.currentTimeMillis();
         MatcherAssert.assertThat(
-            attachment.date().getTime(), Matchers.lessThan(after)
+            attachment.date().getTime(), Matchers.lessThanOrEqualTo(after)
         );
         attachments.delete(name);
     }

--- a/netbout-web/src/test/java/com/netbout/dynamo/DyAttachmentITCase.java
+++ b/netbout-web/src/test/java/com/netbout/dynamo/DyAttachmentITCase.java
@@ -96,8 +96,8 @@ public final class DyAttachmentITCase {
             new DyBase().user(new URN("urn:test:89636")).aliases();
         aliases.add(alias);
         final Inbox inbox = aliases.iterate().iterator().next().inbox();
-        final Bout bout = inbox.bout(inbox.start());
-        final Attachments attachments = bout.attachments();
+        final Attachments attachments = inbox.bout(inbox.start())
+            .attachments();
         final String name = "name";
         attachments.create(name);
         final Attachment attachment = attachments.get(name);

--- a/netbout-web/src/test/java/com/netbout/dynamo/DyAttachmentITCase.java
+++ b/netbout-web/src/test/java/com/netbout/dynamo/DyAttachmentITCase.java
@@ -107,7 +107,7 @@ public final class DyAttachmentITCase {
         attachments.delete(name);
     }
 
-    // @todo #839:30min DyAttachment Item should have an attribute for the 
+    // @todo #839:30min DyAttachment Item should have an attribute for the
     //  creation time of the attachment. Remove @Ignore from this test to check
     //  it. After this, update XeAttachment.make(), RtAttachment.date() and
     //  ignored test at RtAttachmentsITCase.

--- a/netbout-web/src/test/java/com/netbout/dynamo/DyAttachmentITCase.java
+++ b/netbout-web/src/test/java/com/netbout/dynamo/DyAttachmentITCase.java
@@ -107,9 +107,9 @@ public final class DyAttachmentITCase {
         attachments.delete(name);
     }
 
-    // @todo #839 DyAttachment Item should have an attribute for the creation
-    //  time of the attachment. Remove @Ignore from this test to check it.
-    //  After this, update XeAttachment.make(), RtAttachment.date() and
+    // @todo #839:30min DyAttachment Item should have an attribute for the 
+    //  creation time of the attachment. Remove @Ignore from this test to check
+    //  it. After this, update XeAttachment.make(), RtAttachment.date() and
     //  ignored test at RtAttachmentsITCase.
     /**
      * DyAttachment can obtain the creation date of an attachment.

--- a/netbout-web/src/test/java/com/netbout/dynamo/DyAttachmentITCase.java
+++ b/netbout-web/src/test/java/com/netbout/dynamo/DyAttachmentITCase.java
@@ -107,10 +107,6 @@ public final class DyAttachmentITCase {
         attachments.delete(name);
     }
 
-    // @todo #839:30min DyAttachment Item should have an attribute for the
-    //  creation time of the attachment. Remove @Ignore from this test to check
-    //  it. After this, update XeAttachment.make(), RtAttachment.date() and
-    //  ignored test at RtAttachmentsITCase.
     /**
      * DyAttachment can obtain the creation date of an attachment.
      * @throws Exception If there is some problem inside
@@ -118,13 +114,12 @@ public final class DyAttachmentITCase {
     @Ignore
     @Test
     public void obtainsCreationDate() throws Exception {
-        final String alias = "brown";
         final Aliases aliases =
             new DyBase().user(new URN("urn:test:89637")).aliases();
-        aliases.add(alias);
+        aliases.add("brown");
         final Inbox inbox = aliases.iterate().iterator().next().inbox();
-        final Bout bout = inbox.bout(inbox.start());
-        final Attachments attachments = bout.attachments();
+        final Attachments attachments =
+            inbox.bout(inbox.start()).attachments();
         final long before = System.currentTimeMillis();
         final String name = "attach-name";
         attachments.create(name);

--- a/netbout-web/src/test/java/com/netbout/dynamo/DyAttachmentITCase.java
+++ b/netbout-web/src/test/java/com/netbout/dynamo/DyAttachmentITCase.java
@@ -108,9 +108,9 @@ public final class DyAttachmentITCase {
     }
 
     // @todo #839 DyAttachment Item should have an attribute for the creation
-    // time of the attachment. Remove @Ignore from this test to check it.
-    // After this, update XeAttachment.make(), RtAttachment.date() and
-    // ignored test at RtAttachmentsITCase.
+    //  time of the attachment. Remove @Ignore from this test to check it.
+    //  After this, update XeAttachment.make(), RtAttachment.date() and
+    //  ignored test at RtAttachmentsITCase.
     /**
      * DyAttachment can obtain the creation date of an attachment.
      * @throws Exception If there is some problem inside

--- a/netbout-web/src/test/java/com/netbout/dynamo/DyAttachmentITCase.java
+++ b/netbout-web/src/test/java/com/netbout/dynamo/DyAttachmentITCase.java
@@ -38,6 +38,7 @@ import javax.ws.rs.core.MediaType;
 import org.apache.commons.io.IOUtils;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.junit.Ignore;
 import org.junit.Test;
 
 /**
@@ -84,4 +85,57 @@ public final class DyAttachmentITCase {
         );
     }
 
+    /**
+     * DyAttachment can obtain author of an attachment.
+     * @throws Exception If there is some problem inside
+     */
+    @Test
+    public void obtainsAuthor() throws Exception {
+        final String alias = "charlie";
+        final Aliases aliases =
+            new DyBase().user(new URN("urn:test:89636")).aliases();
+        aliases.add(alias);
+        final Inbox inbox = aliases.iterate().iterator().next().inbox();
+        final Bout bout = inbox.bout(inbox.start());
+        final Attachments attachments = bout.attachments();
+        final String name = "name";
+        attachments.create(name);
+        final Attachment attachment = attachments.get(name);
+        MatcherAssert.assertThat(
+            attachment.author(), Matchers.equalTo(alias)
+        );
+        attachments.delete(name);
+    }
+
+    // @todo #839 DyAttachment Item should have an attribute for the creation
+    // time of the attachment. Remove @Ignore from this test to check it.
+    // After this, update XeAttachment.make(), RtAttachment.date() and
+    // ignored test at RtAttachmentsITCase.
+    /**
+     * DyAttachment can obtain the creation date of an attachment.
+     * @throws Exception If there is some problem inside
+     */
+    @Ignore
+    @Test
+    public void obtainsCreationDate() throws Exception {
+        final String alias = "brown";
+        final Aliases aliases =
+            new DyBase().user(new URN("urn:test:89637")).aliases();
+        aliases.add(alias);
+        final Inbox inbox = aliases.iterate().iterator().next().inbox();
+        final Bout bout = inbox.bout(inbox.start());
+        final Attachments attachments = bout.attachments();
+        final long before = System.currentTimeMillis();
+        final String name = "attach-name";
+        attachments.create(name);
+        final Attachment attachment = attachments.get(name);
+        MatcherAssert.assertThat(
+            attachment.date().getTime(), Matchers.greaterThan(before)
+        );
+        final long after = System.currentTimeMillis();
+        MatcherAssert.assertThat(
+            attachment.date().getTime(), Matchers.lessThan(after)
+        );
+        attachments.delete(name);
+    }
 }


### PR DESCRIPTION
Fixes for #839:
- Added author() and date() methods to Attachment.
- Implemented those methods in all Attachment implementations.
- Added Unit and Integration tests.
- Added new puzzle in `DyAttachmentITCase`