### PR TITLE
Message in case of no results for search

### DIFF
--- a/netbout-web/src/main/scss/layout.scss
+++ b/netbout-web/src/main/scss/layout.scss
@@ -217,3 +217,7 @@ $width: 750px;
   font-weight: bolder;
   font-size: 2 * $em;
 }
+
+.alligned {
+    margin-top:36px;
+}

--- a/netbout-web/src/main/scss/layout.scss
+++ b/netbout-web/src/main/scss/layout.scss
@@ -218,6 +218,6 @@ $width: 750px;
   font-size: 2 * $em;
 }
 
-.alligned {
-    margin-top:36px;
+.allgned {
+    margin-top: 36px;
 }

--- a/netbout-web/src/main/scss/layout.scss
+++ b/netbout-web/src/main/scss/layout.scss
@@ -218,6 +218,6 @@ $width: 750px;
   font-size: 2 * $em;
 }
 
-.allgned {
+.aligned {
     margin-top: 36px;
 }

--- a/netbout-web/src/main/xsl/inbox.xsl
+++ b/netbout-web/src/main/xsl/inbox.xsl
@@ -81,7 +81,7 @@
                         </p>
                     </xsl:when>
                     <xsl:otherwise>
-                        <p class="red alligned">
+                        <p id="noresmsg" class="red alligned">
                             <strong>No bouts found for query "<xsl:value-of select="query"/></strong>"
                         </p>
                     </xsl:otherwise>

--- a/netbout-web/src/main/xsl/inbox.xsl
+++ b/netbout-web/src/main/xsl/inbox.xsl
@@ -61,7 +61,7 @@
             <xsl:when test="count(bouts/bout) = 0">
                 <xsl:choose>
                     <xsl:when test="query = ''">
-                        <p class="alligned">
+                        <p class="allgned">
                             Someone invited you here?
                             If yes, give him your alias
                             <strong>@<xsl:value-of select="alias/name"/></strong>
@@ -81,7 +81,7 @@
                         </p>
                     </xsl:when>
                     <xsl:otherwise>
-                        <p id="noresmsg" class="red alligned">
+                        <p id="noresmsg" class="red allgned">
                             <strong>No bouts found for query "<xsl:value-of select="query"/></strong>"
                         </p>
                     </xsl:otherwise>

--- a/netbout-web/src/main/xsl/inbox.xsl
+++ b/netbout-web/src/main/xsl/inbox.xsl
@@ -59,24 +59,33 @@
     <xsl:template match="page" mode="body">
         <xsl:choose>
             <xsl:when test="count(bouts/bout) = 0">
-                <p style="margin-top:36px;">
-                    Someone invited you here?
-                    If yes, give him your alias
-                    <strong>@<xsl:value-of select="alias/name"/></strong>
-                    and wait. You will be invited to a private
-                    conversation. The rest is very simple :)
-                </p>
-                <p>
-                    If you registered here just because you are
-                    curios what Netbout is, we can explain. It is
-                    a place for your private talks, made right. You start
-                    a new conversation, invite
-                    your friends, post messages, share documents, and never
-                    reveal your real identity. Try to start one ("start"
-                    link is at the top right corner) and invite
-                    <strong>@help</strong>. You'll get the idea
-                    quite soon :)
-                </p>
+                <xsl:choose>
+                    <xsl:when test="query = ''">
+                        <p style="margin-top:36px;">
+                            Someone invited you here?
+                            If yes, give him your alias
+                            <strong>@<xsl:value-of select="alias/name"/></strong>
+                            and wait. You will be invited to a private
+                            conversation. The rest is very simple :)
+                        </p>
+                        <p>
+                            If you registered here just because you are
+                            curios what Netbout is, we can explain. It is
+                            a place for your private talks, made right. You start
+                            a new conversation, invite
+                            your friends, post messages, share documents, and never
+                            reveal your real identity. Try to start one ("start"
+                            link is at the top right corner) and invite
+                            <strong>@help</strong>. You'll get the idea
+                            quite soon :)
+                        </p>
+                    </xsl:when>
+                    <xsl:otherwise>
+                        <p class="red" style="margin-top:36px;">
+                            <strong>No bouts found for query "<xsl:value-of select="query"/></strong>"
+                        </p>
+                    </xsl:otherwise>
+                </xsl:choose>
             </xsl:when>
             <xsl:otherwise>
                 <div id="bouts" data-more="{bouts/bout[position()=last()]/links/link[@rel='more']/@href}">

--- a/netbout-web/src/main/xsl/inbox.xsl
+++ b/netbout-web/src/main/xsl/inbox.xsl
@@ -61,7 +61,7 @@
             <xsl:when test="count(bouts/bout) = 0">
                 <xsl:choose>
                     <xsl:when test="query = ''">
-                        <p style="margin-top:36px;">
+                        <p class="alligned">
                             Someone invited you here?
                             If yes, give him your alias
                             <strong>@<xsl:value-of select="alias/name"/></strong>
@@ -81,7 +81,7 @@
                         </p>
                     </xsl:when>
                     <xsl:otherwise>
-                        <p class="red" style="margin-top:36px;">
+                        <p class="red alligned">
                             <strong>No bouts found for query "<xsl:value-of select="query"/></strong>"
                         </p>
                     </xsl:otherwise>

--- a/netbout-web/src/main/xsl/inbox.xsl
+++ b/netbout-web/src/main/xsl/inbox.xsl
@@ -61,7 +61,7 @@
             <xsl:when test="count(bouts/bout) = 0">
                 <xsl:choose>
                     <xsl:when test="query = ''">
-                        <p class="allgned">
+                        <p class="aligned">
                             Someone invited you here?
                             If yes, give him your alias
                             <strong>@<xsl:value-of select="alias/name"/></strong>
@@ -81,7 +81,7 @@
                         </p>
                     </xsl:when>
                     <xsl:otherwise>
-                        <p id="noresmsg" class="red allgned">
+                        <p id="noresmsg" class="red aligned">
                             <strong>No bouts found for query "<xsl:value-of select="query"/></strong>"
                         </p>
                     </xsl:otherwise>

--- a/netbout-web/src/test/casperjs/inbox-noresults-message.js
+++ b/netbout-web/src/test/casperjs/inbox-noresults-message.js
@@ -1,0 +1,32 @@
+/*globals casper:false */
+casper.test.begin(
+    'inbox can list bouts',
+    function (test) {
+        casper.start().then(
+            function() {
+                this.open(
+                    casper.cli.get('home') + "/search?q=invalidsearch",
+                    {
+                        method: 'GET',
+                        headers: {
+                            'Accept': 'text/html'
+                        }
+                    }
+                ).then(
+                    function() {
+                        test.assertHttpStatus(200, 'search results page status is not 200!');
+                        test.assert(
+                            document.querySelector("#noresmsg").textContent ===
+                            'No bouts found for query "invalidsearch"'
+                        )
+                    }
+                )
+            }
+        );
+        casper.run(
+            function () {
+                test.done();
+            }
+        );
+    }
+);

--- a/netbout-web/src/test/casperjs/inbox-noresults-message.js
+++ b/netbout-web/src/test/casperjs/inbox-noresults-message.js
@@ -1,6 +1,6 @@
 /*globals casper:false */
 casper.test.begin(
-    'message is displayed if there are no test results',
+    'message is displayed if there are no search results',
     function (test) {
         casper.start().then(
             function() {

--- a/netbout-web/src/test/casperjs/inbox-noresults-message.js
+++ b/netbout-web/src/test/casperjs/inbox-noresults-message.js
@@ -1,6 +1,6 @@
 /*globals casper:false */
 casper.test.begin(
-    'inbox can list bouts',
+    'message is displayed if there are no test results',
     function (test) {
         casper.start().then(
             function() {


### PR DESCRIPTION
This is for issue #855  .

Modified the display conditions in ``inbox.xsl`` . If we have no bouts to display, we check if the query was empty.

 **If it was empty** (so no search was performed by the user - the inbox page is simply opened) then we show the "welcome" text with ``Someone invited you here? ... ``

**else, if the query is not empty** then we show a red message saying ``No bouts found for query "given query"``

It's done like this since a search is performed anyway at each page load: either the user made a search and the page loads with the given query, or the page is loaded with no query and the search is performed for all (``*``) bouts.

cc: @mkordas Pls let me know if this behavior is what you want. I see no reason for a reviewer to not accept this so I'm asking you directly to save some time :D 

I tested manually the following cases and it works fine: 

1) no results when there are bouts in the inbox;
2) no results when the inbox is empty; 
3) search for empty string when there are bouts in the inbox (should list all of them)
4) search for empty string when there are no bouts in the inbox (should give the message ``Someone invited you here? ... ``

![image](https://cloud.githubusercontent.com/assets/6305156/17504352/e6ac91da-5e00-11e6-9bd2-8362eaf1c1fa.png)
