### PR TITLE
Updated jcabi-parent

### DIFF
--- a/netbout-client/src/test/java/com/netbout/client/NbRule.java
+++ b/netbout-client/src/test/java/com/netbout/client/NbRule.java
@@ -56,6 +56,7 @@ public final class NbRule implements TestRule {
             System.getProperty("netbout.url", "http://www.netbout.com")
         );
         Assume.assumeNotNull(token);
+        Assume.assumeTrue(!token.isEmpty());
         return new CdUser(new RtUser(url, token));
     }
 

--- a/netbout-client/src/test/java/com/netbout/client/RtFriendsITCase.java
+++ b/netbout-client/src/test/java/com/netbout/client/RtFriendsITCase.java
@@ -97,7 +97,9 @@ public final class RtFriendsITCase {
      */
     @Test (expected = AssertionError.class)
     public void throwsExceptionIfInvalidToken() throws Exception {
-        Assume.assumeNotNull(System.getProperty("netbout.token"));
+        final String token = System.getProperty("netbout.token");
+        Assume.assumeNotNull(token);
+        Assume.assumeTrue(!token.isEmpty());
         final User user = new RtUser(
             URI.create(
                 System.getProperty("netbout.url", "http://www.netbout.com")

--- a/pom.xml
+++ b/pom.xml
@@ -45,13 +45,9 @@
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <!--@todo #909:30min jcabi-parent used by Netbout is pretty outdated,
-              we should update it to the latest version and make sure the build
-              is passing
-        -->
         <groupId>com.jcabi</groupId>
         <artifactId>parent</artifactId>
-        <version>0.32.1</version>
+        <version>0.45</version>
     </parent>
     <groupId>com.netbout</groupId>
     <artifactId>netbout</artifactId>


### PR DESCRIPTION
PR for #1119 .
Other changes: Added one more assumption, since apparently maven-failsafe-plugin 2.19 reads null system properties as empty strings and ``mvn clean install -Pqulice`` would fail because of IT tests
E.g.
```
...
 <artifactId>maven-failsafe-plugin</artifactId> 
    <configuration>
        <systemPropertyVariables>
            <netbout.token>${netbout.token}</netbout.token>
        </systemPropertyVariables>
    </configuration>
...
```
^ Before, the sys variable was set null, now it's set empty string and the IT tests faile without the new assumption.