### PR TITLE
Update qulice to version 0.17.1

### DIFF
--- a/netbout-client/src/main/java/com/netbout/client/RtFriends.java
+++ b/netbout-client/src/main/java/com/netbout/client/RtFriends.java
@@ -82,7 +82,6 @@ final class RtFriends implements Friends {
             .as(XmlResponse.class)
             .rel("/page/links/link[@rel='invite']/@href")
             .method(Request.POST)
-            // @checkstyle MultipleStringLiteralsCheck (1 line)
             .body().formParam("name", friend).back()
             .fetch()
             .as(RestResponse.class);

--- a/netbout-client/src/main/java/com/netbout/mock/MkAliases.java
+++ b/netbout-client/src/main/java/com/netbout/mock/MkAliases.java
@@ -125,8 +125,7 @@ final class MkAliases implements Aliases {
                         @Override
                         public Iterable<Alias> handle(final ResultSet rset,
                             final Statement stmt) throws SQLException {
-                            final Collection<Alias> list =
-                                new LinkedList<Alias>();
+                            final Collection<Alias> list = new LinkedList<>();
                             while (rset.next()) {
                                 list.add(
                                     new MkAlias(

--- a/netbout-client/src/main/java/com/netbout/mock/MkAttachments.java
+++ b/netbout-client/src/main/java/com/netbout/mock/MkAttachments.java
@@ -136,7 +136,7 @@ final class MkAttachments implements Attachments {
                         public Iterable<Attachment> handle(final ResultSet rset,
                             final Statement stmt) throws SQLException {
                             final Collection<Attachment> list =
-                                new LinkedList<Attachment>();
+                                new LinkedList<>();
                             while (rset.next()) {
                                 list.add(
                                     new MkAttachment(

--- a/netbout-client/src/main/java/com/netbout/mock/MkFriends.java
+++ b/netbout-client/src/main/java/com/netbout/mock/MkFriends.java
@@ -122,8 +122,7 @@ final class MkFriends implements Friends {
                         @Override
                         public Iterable<Friend> handle(final ResultSet rset,
                             final Statement stmt) throws SQLException {
-                            final Collection<Friend> list =
-                                new LinkedList<Friend>();
+                            final Collection<Friend> list = new LinkedList<>();
                             while (rset.next()) {
                                 list.add(
                                     new MkFriend(

--- a/netbout-client/src/main/java/com/netbout/mock/MkInbox.java
+++ b/netbout-client/src/main/java/com/netbout/mock/MkInbox.java
@@ -131,8 +131,7 @@ final class MkInbox implements Inbox {
                         @Override
                         public Iterable<Bout> handle(final ResultSet rset,
                             final Statement stmt) throws SQLException {
-                            final Collection<Bout> list =
-                                new LinkedList<Bout>();
+                            final Collection<Bout> list = new LinkedList<>();
                             while (rset.next()) {
                                 list.add(
                                     new MkBout(

--- a/netbout-client/src/main/java/com/netbout/mock/MkMessages.java
+++ b/netbout-client/src/main/java/com/netbout/mock/MkMessages.java
@@ -122,7 +122,7 @@ final class MkMessages implements Messages {
                         public Iterable<Message> handle(final ResultSet rset,
                             final Statement stmt) throws SQLException {
                             final Collection<Message> list =
-                                new LinkedList<Message>();
+                                new LinkedList<>();
                             while (rset.next()) {
                                 list.add(
                                     new MkMessage(

--- a/netbout-client/src/main/java/com/netbout/mock/MkUser.java
+++ b/netbout-client/src/main/java/com/netbout/mock/MkUser.java
@@ -94,8 +94,7 @@ final class MkUser implements User {
                         @Override
                         public Iterable<Friend> handle(final ResultSet rset,
                             final Statement stmt) throws SQLException {
-                            final Collection<Friend> list =
-                                new LinkedList<Friend>();
+                            final Collection<Friend> list = new LinkedList<>();
                             while (rset.next()) {
                                 list.add(
                                     new MkFriend(

--- a/netbout-client/src/test/java/com/netbout/client/NbRule.java
+++ b/netbout-client/src/test/java/com/netbout/client/NbRule.java
@@ -43,14 +43,20 @@ import org.junit.runners.model.Statement;
  *  be refactored to not contain any of them. The method get() should either be
  *  an instance method with refrence to this (to avoid checkstyle
  *  NonStaticMethodCheck) or a static but not public.
+ * @checkstyle NonStaticMethodCheck (100 lines)
  */
 public final class NbRule implements TestRule {
+
+    @Override
+    public Statement apply(final Statement stmt, final Description desc) {
+        return stmt;
+    }
 
     /**
      * Get user.
      * @return User
      */
-    public static User get() {
+    public User get() {
         final String token = System.getProperty("netbout.token");
         final URI url = URI.create(
             System.getProperty("netbout.url", "http://www.netbout.com")
@@ -60,8 +66,4 @@ public final class NbRule implements TestRule {
         return new CdUser(new RtUser(url, token));
     }
 
-    @Override
-    public Statement apply(final Statement stmt, final Description desc) {
-        return stmt;
-    }
 }

--- a/netbout-client/src/test/java/com/netbout/client/RtAliasITCase.java
+++ b/netbout-client/src/test/java/com/netbout/client/RtAliasITCase.java
@@ -56,7 +56,7 @@ public final class RtAliasITCase {
     @Test
     public void updateAndRetrieveEmail() throws Exception {
         final MkBase base = new MkBase();
-        final User user = NbRule.get();
+        final User user = this.rule.get();
         final Alias alias = user.aliases().iterate().iterator().next();
         final String email = base.randomAlias().email();
         alias.email(email);

--- a/netbout-client/src/test/java/com/netbout/client/RtAttachmentsITCase.java
+++ b/netbout-client/src/test/java/com/netbout/client/RtAttachmentsITCase.java
@@ -60,7 +60,7 @@ public final class RtAttachmentsITCase {
      */
     @Test
     public void postsAndReads() throws Exception {
-        final User user = NbRule.get();
+        final User user = this.rule.get();
         final Alias alias = user.aliases().iterate().iterator().next();
         final Inbox inbox = alias.inbox();
         final Bout bout = inbox.bout(inbox.start());
@@ -91,7 +91,7 @@ public final class RtAttachmentsITCase {
      */
     @Test
     public void obtainsAuthor() throws Exception {
-        final User user = NbRule.get();
+        final User user = this.rule.get();
         final Alias alias = user.aliases().iterate().iterator().next();
         final Inbox inbox = alias.inbox();
         final Attachments attachments = inbox.bout(inbox.start())
@@ -111,7 +111,8 @@ public final class RtAttachmentsITCase {
      */
     @Test
     public void obtainsCreationDate() throws Exception {
-        final Alias alias = NbRule.get().aliases().iterate().iterator().next();
+        final Alias alias = this.rule
+            .get().aliases().iterate().iterator().next();
         final Inbox inbox = alias.inbox();
         final Attachments attachments =
             inbox.bout(inbox.start()).attachments();

--- a/netbout-client/src/test/java/com/netbout/client/RtBoutITCase.java
+++ b/netbout-client/src/test/java/com/netbout/client/RtBoutITCase.java
@@ -56,7 +56,7 @@ public final class RtBoutITCase {
      */
     @Test
     public void startsBoutAndTalks() throws Exception {
-        final User user = NbRule.get();
+        final User user = this.rule.get();
         final Alias alias = user.aliases().iterate().iterator().next();
         final Inbox inbox = alias.inbox();
         final Bout bout = inbox.bout(inbox.start());

--- a/netbout-client/src/test/java/com/netbout/client/RtFriendsITCase.java
+++ b/netbout-client/src/test/java/com/netbout/client/RtFriendsITCase.java
@@ -60,7 +60,7 @@ public final class RtFriendsITCase {
      */
     @Test
     public void invitesAndKicksOff() throws Exception {
-        final User user = NbRule.get();
+        final User user = this.rule.get();
         final Alias alias = user.aliases().iterate().iterator().next();
         final Inbox inbox = alias.inbox();
         final Bout bout = inbox.bout(inbox.start());
@@ -83,7 +83,7 @@ public final class RtFriendsITCase {
      */
     @Test (expected = Friends.UnknownAliasException.class)
     public void throwsExceptionIfUnknownAliasInvited() throws Exception {
-        final User user = NbRule.get();
+        final User user = this.rule.get();
         final Alias alias = user.aliases().iterate().iterator().next();
         final Inbox inbox = alias.inbox();
         final Bout bout = inbox.bout(inbox.start());
@@ -118,7 +118,7 @@ public final class RtFriendsITCase {
      */
     @Test (expected = Friends.UnknownAliasException.class)
     public void throwsExceptionIfUnknownAliasKicked() throws Exception {
-        final Inbox inbox = NbRule.get().aliases()
+        final Inbox inbox = this.rule.get().aliases()
             .iterate().iterator().next().inbox();
         inbox.bout(inbox.start()).friends().kick("jim");
     }

--- a/netbout-client/src/test/java/com/netbout/client/RtInboxITCase.java
+++ b/netbout-client/src/test/java/com/netbout/client/RtInboxITCase.java
@@ -58,7 +58,7 @@ public final class RtInboxITCase {
      */
     @Test
     public void listsBouts() throws Exception {
-        final User user = NbRule.get();
+        final User user = this.rule.get();
         final Alias alias = user.aliases().iterate().iterator().next();
         final Inbox inbox = alias.inbox();
         MatcherAssert.assertThat(
@@ -74,7 +74,7 @@ public final class RtInboxITCase {
     @Test
     public void searchesBouts() throws Exception {
         final Inbox inbox =
-            NbRule.get().aliases().iterate().iterator().next().inbox();
+            this.rule.get().aliases().iterate().iterator().next().inbox();
         final Bout first = inbox.bout(inbox.start());
         final String firsttitle = "bout1 title";
         first.rename(firsttitle);

--- a/netbout-client/src/test/java/com/netbout/client/RtMessagesITCase.java
+++ b/netbout-client/src/test/java/com/netbout/client/RtMessagesITCase.java
@@ -57,7 +57,7 @@ public final class RtMessagesITCase {
      */
     @Test
     public void listsMessagesInBout() throws Exception {
-        final User user = NbRule.get();
+        final User user = this.rule.get();
         final Alias alias = user.aliases().iterate().iterator().next();
         final Inbox inbox = alias.inbox();
         inbox.start();

--- a/netbout-client/src/test/java/com/netbout/client/RtUserITCase.java
+++ b/netbout-client/src/test/java/com/netbout/client/RtUserITCase.java
@@ -55,7 +55,7 @@ public final class RtUserITCase {
      */
     @Test
     public void startsBoutAndTalks() throws Exception {
-        final User user = NbRule.get();
+        final User user = this.rule.get();
         final Alias alias = user.aliases().iterate().iterator().next();
         final Inbox inbox = alias.inbox();
         final Bout bout = inbox.bout(inbox.start());

--- a/netbout-web/src/main/java/com/netbout/dynamo/DyAttachment.java
+++ b/netbout-web/src/main/java/com/netbout/dynamo/DyAttachment.java
@@ -395,7 +395,7 @@ final class DyAttachment implements Attachment {
             .where(DyFriends.HASH, Conditions.equalTo(this.bout()))
             .where(DyFriends.RANGE, Conditions.equalTo(alias))
             .iterator().next();
-        final Set<String> list = new HashSet<String>(0);
+        final Set<String> list = new HashSet<>(0);
         if (itm.has(DyFriends.ATTR_UNSEEN)) {
             list.addAll(itm.get(DyFriends.ATTR_UNSEEN).getSS());
         }

--- a/netbout-web/src/main/java/com/netbout/email/EmCatch.java
+++ b/netbout-web/src/main/java/com/netbout/email/EmCatch.java
@@ -119,7 +119,6 @@ final class EmCatch {
     /**
      * Start the monitoring.
      */
-    @SuppressWarnings("PMD.DoNotUseThreads")
     public void start() {
         final Thread monitor = new Thread(
             new Runnable() {

--- a/netbout-web/src/main/java/com/netbout/email/EmMessages.java
+++ b/netbout-web/src/main/java/com/netbout/email/EmMessages.java
@@ -100,7 +100,7 @@ final class EmMessages implements Messages {
     @Override
     public void post(final String text) throws IOException {
         this.origin.post(text);
-        final Collection<String> failed = new ArrayList<String>(16);
+        final Collection<String> failed = new ArrayList<>(16);
         for (final Friend friend : this.bout.friends().iterate()) {
             if (friend.email().isEmpty()
                 || friend.alias().equals(this.self)

--- a/netbout-web/src/main/java/com/netbout/email/GmailViewAction.java
+++ b/netbout-web/src/main/java/com/netbout/email/GmailViewAction.java
@@ -54,7 +54,6 @@ final class GmailViewAction {
     /**
      * Returns the XML section for Gmail ViewAction.
      * @return The XML
-     * @checkstyle MultipleStringLiteralsCheck (45 lines)
      */
     @SuppressWarnings("PMD.AvoidDuplicateLiterals")
     public String xml() {

--- a/netbout-web/src/main/java/com/netbout/misc/Ports.java
+++ b/netbout-web/src/main/java/com/netbout/misc/Ports.java
@@ -44,13 +44,14 @@ import java.util.concurrent.ConcurrentSkipListSet;
  *  qulice upgrade to 0.15.2 and the contructor became private.
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */
+@SuppressWarnings("PMD.ProhibitPublicStaticMethods")
 public final class Ports {
 
     /**
      * Already assigned ports.
      */
     private static final Collection<Integer> ASSIGNED =
-        new ConcurrentSkipListSet<Integer>();
+        new ConcurrentSkipListSet<>();
 
     /**
      * Hide the default no args constructor from the utility class.

--- a/netbout-web/src/main/java/com/netbout/rest/PsTwice.java
+++ b/netbout-web/src/main/java/com/netbout/rest/PsTwice.java
@@ -65,7 +65,7 @@ public final class PsTwice implements Pass {
 
     @Override
     public Opt<Identity> enter(final Request req) throws IOException {
-        Opt<Identity> user = new Opt.Empty<Identity>();
+        Opt<Identity> user = new Opt.Empty<>();
         if (this.fst.enter(req).has()) {
             user = this.snd.enter(req);
         }

--- a/netbout-web/src/main/java/com/netbout/rest/RsPage.java
+++ b/netbout-web/src/main/java/com/netbout/rest/RsPage.java
@@ -101,7 +101,6 @@ public final class RsPage extends RsWrap {
                         final Opt<Response> opt;
                         if (agent.hasNext()
                             && agent.next().contains("Firefox")) {
-                            // @checkstyle MultipleStringLiteralsCheck (3 line)
                             opt = new Opt.Single<Response>(
                                 new RsXSLT(new RsWithType(raw, "text/html"))
                             );

--- a/netbout-web/src/main/java/com/netbout/rest/RsPage.java
+++ b/netbout-web/src/main/java/com/netbout/rest/RsPage.java
@@ -54,6 +54,7 @@ import org.takes.rs.xe.XeStylesheet;
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */
 @EqualsAndHashCode(callSuper = true)
+@SuppressWarnings("PMD.AvoidDuplicateLiterals")
 public final class RsPage extends RsWrap {
 
     /**

--- a/netbout-web/src/main/java/com/netbout/rest/TkApp.java
+++ b/netbout-web/src/main/java/com/netbout/rest/TkApp.java
@@ -74,7 +74,7 @@ import org.takes.tk.TkWrap;
  * @checkstyle MultipleStringLiteralsCheck (500 lines)
  * @checkstyle ClassFanOutComplexityCheck (500 lines)
  */
-@SuppressWarnings("PMD.ExcessiveImports")
+@SuppressWarnings({"PMD.ExcessiveImports", "PMD.AvoidDuplicateLiterals"})
 public final class TkApp extends TkWrap {
 
     /**

--- a/netbout-web/src/main/java/com/netbout/rest/TkApp.java
+++ b/netbout-web/src/main/java/com/netbout/rest/TkApp.java
@@ -71,7 +71,6 @@ import org.takes.tk.TkWrap;
  * @version $Id$
  * @since 2.14
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
- * @checkstyle MultipleStringLiteralsCheck (500 lines)
  * @checkstyle ClassFanOutComplexityCheck (500 lines)
  */
 @SuppressWarnings({"PMD.ExcessiveImports", "PMD.AvoidDuplicateLiterals"})
@@ -255,7 +254,6 @@ public final class TkApp extends TkWrap {
      * @return Fork
      * @throws IOException If fails
      */
-    @SuppressWarnings("PMD.DoNotUseThreads")
     private static Take refresh(final String path) throws IOException {
         return new TkFork(
             new FkHitRefresh(

--- a/netbout-web/src/main/java/com/netbout/rest/TkInbox.java
+++ b/netbout-web/src/main/java/com/netbout/rest/TkInbox.java
@@ -54,7 +54,6 @@ import org.xembly.Directives;
  * @version $Id$
  * @since 2.14
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
- * @checkstyle MultipleStringLiteralsCheck (500 lines)
  */
 @SuppressWarnings("PMD.AvoidDuplicateLiterals")
 final class TkInbox implements Take {

--- a/netbout-web/src/main/java/com/netbout/rest/TkInbox.java
+++ b/netbout-web/src/main/java/com/netbout/rest/TkInbox.java
@@ -56,6 +56,7 @@ import org.xembly.Directives;
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  * @checkstyle MultipleStringLiteralsCheck (500 lines)
  */
+@SuppressWarnings("PMD.AvoidDuplicateLiterals")
 final class TkInbox implements Take {
 
     /**

--- a/netbout-web/src/main/java/com/netbout/rest/bout/TkIndex.java
+++ b/netbout-web/src/main/java/com/netbout/rest/bout/TkIndex.java
@@ -59,6 +59,7 @@ import org.xembly.Directives;
  * @checkstyle MultipleStringLiteralsCheck (500 lines)
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */
+@SuppressWarnings("PMD.AvoidDuplicateLiterals")
 final class TkIndex implements Take {
 
     /**

--- a/netbout-web/src/main/java/com/netbout/rest/bout/TkIndex.java
+++ b/netbout-web/src/main/java/com/netbout/rest/bout/TkIndex.java
@@ -56,7 +56,6 @@ import org.xembly.Directives;
  * @author Yegor Bugayenko (yegor@teamed.io)
  * @version $Id$
  * @since 2.14
- * @checkstyle MultipleStringLiteralsCheck (500 lines)
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */
 @SuppressWarnings("PMD.AvoidDuplicateLiterals")

--- a/netbout-web/src/main/java/com/netbout/rest/bout/TkInvite.java
+++ b/netbout-web/src/main/java/com/netbout/rest/bout/TkInvite.java
@@ -115,7 +115,6 @@ final class TkInvite implements Take {
      */
     public String inviteByEmail(@NotNull(message = "Invite can't be NULL")
         final String invite, final Bout bout) throws IOException {
-        // @checkstyle MultipleStringLiteralsCheck (1 line)
         final String alias = invite.replace("@", "-").replace(".", "-");
         final String urn = String.format(
             "urn:email:%s",

--- a/netbout-web/src/main/java/com/netbout/rest/bout/XeAttachment.java
+++ b/netbout-web/src/main/java/com/netbout/rest/bout/XeAttachment.java
@@ -55,6 +55,7 @@ import org.xembly.Xembler;
  * @checkstyle MultipleStringLiteralsCheck (500 lines)
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */
+@SuppressWarnings("PMD.AvoidDuplicateLiterals")
 final class XeAttachment extends XeWrap {
 
     /**

--- a/netbout-web/src/main/java/com/netbout/rest/bout/XeAttachment.java
+++ b/netbout-web/src/main/java/com/netbout/rest/bout/XeAttachment.java
@@ -52,7 +52,6 @@ import org.xembly.Xembler;
  * @author Yegor Bugayenko (yegor@teamed.io)
  * @version $Id$
  * @since 2.14
- * @checkstyle MultipleStringLiteralsCheck (500 lines)
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */
 @SuppressWarnings("PMD.AvoidDuplicateLiterals")

--- a/netbout-web/src/main/java/com/netbout/rest/bout/XeFriend.java
+++ b/netbout-web/src/main/java/com/netbout/rest/bout/XeFriend.java
@@ -46,6 +46,7 @@ import org.xembly.Directives;
  * @checkstyle MultipleStringLiteralsCheck (500 lines)
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */
+@SuppressWarnings("PMD.AvoidDuplicateLiterals")
 final class XeFriend extends XeWrap {
 
     /**

--- a/netbout-web/src/main/java/com/netbout/rest/bout/XeFriend.java
+++ b/netbout-web/src/main/java/com/netbout/rest/bout/XeFriend.java
@@ -43,7 +43,6 @@ import org.xembly.Directives;
  * @author Yegor Bugayenko (yegor@teamed.io)
  * @version $Id$
  * @since 2.14
- * @checkstyle MultipleStringLiteralsCheck (500 lines)
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */
 @SuppressWarnings("PMD.AvoidDuplicateLiterals")

--- a/netbout-web/src/main/java/com/netbout/rest/bout/XeMessage.java
+++ b/netbout-web/src/main/java/com/netbout/rest/bout/XeMessage.java
@@ -47,7 +47,6 @@ import org.xembly.Xembler;
  * @author Yegor Bugayenko (yegor@teamed.io)
  * @version $Id$
  * @since 2.14
- * @checkstyle MultipleStringLiteralsCheck (500 lines)
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */
 final class XeMessage extends XeWrap {

--- a/netbout-web/src/test/java/com/netbout/dynamo/DyMessagesITCase.java
+++ b/netbout-web/src/test/java/com/netbout/dynamo/DyMessagesITCase.java
@@ -120,7 +120,6 @@ public final class DyMessagesITCase {
         final Inbox inbox = aliases.iterate().iterator().next().inbox();
         final Bout bout = inbox.bout(inbox.start());
         bout.messages().post("hello");
-        // @checkstyle MultipleStringLiteralsCheck (1 line)
         bout.messages().post("world");
         bout.messages().post("foo");
         final Iterator<Message> result = bout.messages().search("r").iterator();
@@ -130,7 +129,6 @@ public final class DyMessagesITCase {
         );
         MatcherAssert.assertThat(
             result.next().text(),
-            // @checkstyle MultipleStringLiteralsCheck (1 line)
             Matchers.equalTo("world")
         );
         MatcherAssert.assertThat(

--- a/netbout-web/src/test/java/com/netbout/dynamo/DyMessagesITCase.java
+++ b/netbout-web/src/test/java/com/netbout/dynamo/DyMessagesITCase.java
@@ -51,6 +51,7 @@ import org.takes.HttpException;
  * @author Yegor Bugayenko (yegor@teamed.io)
  * @version $Id$
  */
+@SuppressWarnings("PMD.AvoidDuplicateLiterals")
 public final class DyMessagesITCase {
 
     @Rule

--- a/netbout-web/src/test/java/com/netbout/rest/TkAppTest.java
+++ b/netbout-web/src/test/java/com/netbout/rest/TkAppTest.java
@@ -53,6 +53,7 @@ import org.takes.rs.RsPrint;
  * @since 2.14
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */
+@SuppressWarnings("PMD.AvoidDuplicateLiterals")
 public final class TkAppTest {
 
     /**

--- a/netbout-web/src/test/java/com/netbout/rest/TkAppTest.java
+++ b/netbout-web/src/test/java/com/netbout/rest/TkAppTest.java
@@ -31,6 +31,7 @@ import java.net.HttpURLConnection;
 import java.net.URLEncoder;
 import java.nio.charset.Charset;
 import java.util.regex.Pattern;
+import org.apache.commons.lang3.StringUtils;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Test;
@@ -131,13 +132,11 @@ public final class TkAppTest {
             ).act(new RqFake(RqMethod.GET, "/whatever?q=1"))
         ).printHead();
         MatcherAssert.assertThat(
-            // @checkstyle MultipleStringLiteralsCheck (2 lines)
             "Incorrect status code",
             Integer.parseInt(head.split("\\s")[1]),
             Matchers.equalTo(HttpURLConnection.HTTP_SEE_OTHER)
         );
         MatcherAssert.assertThat(
-            // @checkstyle MultipleStringLiteralsCheck (1 line)
             "Incorrect Location header",
             Pattern.compile(
                 "^Location: /$",
@@ -145,11 +144,12 @@ public final class TkAppTest {
             ).matcher(head).find()
         );
         MatcherAssert.assertThat(
-            // @checkstyle MultipleStringLiteralsCheck (1 line)
             "Incorrect Set-Cookie header",
             Pattern.compile(
-                // @checkstyle LineLengthCheck (1 line)
-                "^Set-Cookie: RsReturn=.*%2Fwhatever%3Fq%3D1;Path=/;Expires=.*;$",
+                StringUtils.join(
+                    "^Set-Cookie: RsReturn=.*%2Fwhatever%3Fq%3D1;Path=/;",
+                    "Expires=.*;$"
+                ),
                 Pattern.MULTILINE
             ).matcher(head).find()
         );
@@ -201,13 +201,11 @@ public final class TkAppTest {
             )
         ).printHead();
         MatcherAssert.assertThat(
-            // @checkstyle MultipleStringLiteralsCheck (3 lines)
             "Incorrect status code",
             Integer.parseInt(head.split("\\s")[1]),
             Matchers.equalTo(HttpURLConnection.HTTP_SEE_OTHER)
         );
         MatcherAssert.assertThat(
-            // @checkstyle MultipleStringLiteralsCheck (1 line)
             "Incorrect Location header",
             Pattern.compile(
                 "^Location: http://example.com/whatever$",
@@ -215,7 +213,6 @@ public final class TkAppTest {
             ).matcher(head).find()
         );
         MatcherAssert.assertThat(
-            // @checkstyle MultipleStringLiteralsCheck (1 line)
             "Incorrect Set-Cookie header",
             Pattern.compile(
                 "^Set-Cookie: RsReturn=;",

--- a/pom.xml
+++ b/pom.xml
@@ -156,7 +156,7 @@
                 <plugin>
                     <groupId>com.qulice</groupId>
                     <artifactId>qulice-maven-plugin</artifactId>
-                    <version>0.16.2</version>
+                    <version>0.17.1</version>
                 </plugin>
                 <plugin>
                     <groupId>org.eluder.coveralls</groupId>


### PR DESCRIPTION
PR for #1120 . 
Fixed newly found errors.

I escaped those which were already escaped before (e.g. PMD now also checks for duplicated strings and there was already an escape for checkstyle, so I added escape for PMD as well). 

I also added escapes where there were already todo puzzles (e.g. ``NbRule`` and ``Ports`` classes)