### PR TITLE
Detailed e-mail confirmation message and unit test

### DIFF
--- a/netbout-web/src/main/java/com/netbout/email/EmAlias.java
+++ b/netbout-web/src/main/java/com/netbout/email/EmAlias.java
@@ -41,9 +41,9 @@ import com.netbout.spi.Inbox;
 import java.io.IOException;
 import java.net.URI;
 import java.util.Locale;
-import org.apache.commons.lang3.StringUtils;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * Email Alias.

--- a/netbout-web/src/main/java/com/netbout/email/EmAlias.java
+++ b/netbout-web/src/main/java/com/netbout/email/EmAlias.java
@@ -26,7 +26,6 @@
  */
 package com.netbout.email;
 
-import com.google.common.base.Joiner;
 import com.jcabi.aspects.Immutable;
 import com.jcabi.aspects.Loggable;
 import com.jcabi.email.Envelope;
@@ -42,6 +41,7 @@ import com.netbout.spi.Inbox;
 import java.io.IOException;
 import java.net.URI;
 import java.util.Locale;
+import org.apache.commons.lang3.StringUtils;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -125,11 +125,6 @@ final class EmAlias implements Alias {
         new BoutInviteMail(this.postman).send(email, urn, bout);
     }
 
-    // @todo #738:30min  We need to improve the format and content of the
-    //  verification email. Currently, it only asks the user to verify
-    //  the new email by using the provided verification link. We may add
-    //  some header, footer, note like "Ignore this email if you did not
-    //  change your email address", etc.
     @Override
     public void email(final String email, final String link)
         throws IOException {
@@ -145,20 +140,31 @@ final class EmAlias implements Alias {
                     )
                     .with(
                         new EnHTML(
-                            Joiner.on('\n').join(
+                            StringUtils.join(
                                 new Markdown.Default().html(
-                                    "Please verify your new email:"
-                                ), "<br/>",
-                                String.format("<a href=%s>%s</a>", link, link)
+                                    StringUtils.join(
+                                        "Hi,<br/>Your notification e-mail ",
+                                        "address for [netbout](http://",
+                                        "www.netbout.com) has been changed. ",
+                                        "Please verify it by clicking ",
+                                        "[here](", link, ")."
+                                    )
+                                ),
+                                "If you did not change your e-mail address ",
+                                "you can ignore this message <br/>",
+                                "This is an automated e-mail, please ",
+                                "do not reply. If you have any questions, ",
+                                "submit an issue <a href=\"",
+                                "https://www.github.com/yegor256/netbout\"",
+                                ">here</a><br/><br/> Best regards,<br/>",
+                                "Netbout team"
                             )
                         )
                     )
             );
         } catch (final IOException exc) {
             throw new IOException(
-                // @checkstyle StringLiteralsConcatenationCheck (2 lines)
-                "Sorry we were not able to send the verification link to "
-                + "the new email address.", exc
+                "Exception while sending the verification email ", exc
             );
         }
     }

--- a/netbout-web/src/main/java/com/netbout/email/EmAlias.java
+++ b/netbout-web/src/main/java/com/netbout/email/EmAlias.java
@@ -60,6 +60,12 @@ import org.apache.commons.lang3.StringUtils;
 final class EmAlias implements Alias {
 
     /**
+     * Url to the netbout repository.
+     */
+    private static final String NETBOUT_GITHUB =
+        "https://www.github.com/yegor256/netbout";
+
+    /**
      * Original.
      */
     private final transient Alias origin;
@@ -68,12 +74,6 @@ final class EmAlias implements Alias {
      * Postman.
      */
     private final transient Postman postman;
-
-    /**
-     * Url to the netbout repository.
-     */
-    private static final String NETBOUT_GITHUB =
-        "https://www.github.com/yegor256/netbout";
 
     /**
      * Public ctor.

--- a/netbout-web/src/main/java/com/netbout/email/EmAlias.java
+++ b/netbout-web/src/main/java/com/netbout/email/EmAlias.java
@@ -70,6 +70,12 @@ final class EmAlias implements Alias {
     private final transient Postman postman;
 
     /**
+     * Url to the netbout repository.
+     */
+    private static final String NETBOUT_GITHUB =
+        "https://www.github.com/yegor256/netbout";
+
+    /**
      * Public ctor.
      * @param org Origin
      * @param pst Postman
@@ -155,8 +161,8 @@ final class EmAlias implements Alias {
                                 "This is an automated e-mail, please ",
                                 "do not reply. If you have any questions, ",
                                 "submit an issue <a href=\"",
-                                "https://www.github.com/yegor256/netbout\"",
-                                ">here</a><br/><br/> Best regards,<br/>",
+                                EmAlias.NETBOUT_GITHUB,
+                                "\">here</a><br/><br/> Best regards,<br/>",
                                 "Netbout team"
                             )
                         )
@@ -164,7 +170,7 @@ final class EmAlias implements Alias {
             );
         } catch (final IOException exc) {
             throw new IOException(
-                "Exception while sending the verification email ", exc
+                "Exception while sending the verification email.", exc
             );
         }
     }

--- a/netbout-web/src/test/java/com/netbout/email/EmAliasTest.java
+++ b/netbout-web/src/test/java/com/netbout/email/EmAliasTest.java
@@ -103,4 +103,41 @@ public final class EmAliasTest {
             )
         );
     }
+
+    /**
+     * EmAlias can send an email with address confirmation link.
+     * @throws Exception If there is some problem inside
+     */
+    @Test
+    public void sendsConfirmationEmail() throws Exception {
+        final Postman postman = Mockito.mock(Postman.class);   
+        final Alias alias = new EmAlias(new MkBase().randomAlias(), postman);
+        alias.email("mihai@test.com", "netbout.com/test/verification/link");
+        final ArgumentCaptor<Envelope> captor =
+            ArgumentCaptor.forClass(Envelope.class);
+        Mockito.verify(postman).send(captor.capture());
+        final Message msg = captor.getValue().unwrap();
+        MatcherAssert.assertThat(msg.getFrom().length, Matchers.is(1));
+        MatcherAssert.assertThat(
+            msg.getSubject(),
+            Matchers.equalTo("Netbout email verification")
+        );
+        MatcherAssert.assertThat(
+            msg.getAllRecipients()[0].toString(),
+            Matchers.containsString("mihai@test")
+        );
+        final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        MimeMultipart.class.cast(msg.getContent()).writeTo(baos);
+        final String content = new String(baos.toByteArray());
+        MatcherAssert.assertThat(
+            content, Matchers.containsString(
+                "<p>Hi,<br />Your notification e-mail address"
+            )
+        );
+        MatcherAssert.assertThat(
+            content, Matchers.containsString(
+                "<a href=\"netbout.com/test/verification/link\">here</a>"
+            )
+        );
+    }
 }

--- a/netbout-web/src/test/java/com/netbout/email/EmAliasTest.java
+++ b/netbout-web/src/test/java/com/netbout/email/EmAliasTest.java
@@ -119,8 +119,7 @@ public final class EmAliasTest {
         final Message msg = captor.getValue().unwrap();
         MatcherAssert.assertThat(msg.getFrom().length, Matchers.is(1));
         MatcherAssert.assertThat(
-            msg.getSubject(),
-            Matchers.equalTo("Netbout email verification")
+            msg.getSubject(), Matchers.equalTo("Netbout email verification")
         );
         MatcherAssert.assertThat(
             msg.getAllRecipients()[0].toString(),
@@ -128,7 +127,7 @@ public final class EmAliasTest {
         );
         final ByteArrayOutputStream baos = new ByteArrayOutputStream();
         MimeMultipart.class.cast(msg.getContent()).writeTo(baos);
-        final String content = new String(baos.toByteArray());
+        final String content = new String(baos.toByteArray(), "UTF-8");
         MatcherAssert.assertThat(
             content, Matchers.containsString(
                 "<p>Hi,<br />Your notification e-mail address"

--- a/netbout-web/src/test/java/com/netbout/email/EmAliasTest.java
+++ b/netbout-web/src/test/java/com/netbout/email/EmAliasTest.java
@@ -110,7 +110,7 @@ public final class EmAliasTest {
      */
     @Test
     public void sendsConfirmationEmail() throws Exception {
-        final Postman postman = Mockito.mock(Postman.class);   
+        final Postman postman = Mockito.mock(Postman.class);
         final Alias alias = new EmAlias(new MkBase().randomAlias(), postman);
         alias.email("mihai@test.com", "netbout.com/test/verification/link");
         final ArgumentCaptor<Envelope> captor =


### PR DESCRIPTION
PR for #841 .
Added a more detailed verification email message and wrote unit test.
This is how the verification email will look: 
***
<p>Hi,<br />Your notification e-mail address for <a href="http://www.netbout.com">netbout</a> has been changed. Please verify it by clicking <a href="netbout.com/test/verification/link">here</a>.</p>
If you did not change your e-mail address you can ignore this message <br/>This is an automated e-mail, please do not reply. If you have any questions, submit an issue <a href="https://www.github.com/yegor256/netbout">here</a><br/><br/> Best regards,<br/>Netbout team
***

When constructing the message inside ``EmAlias.email(...)`` I would have used ``new Markdown.Default().html([here](...link...))`` for all the anchors, but ``Markdown.html()`` puts everything between ``<p></p>`` tags, so it didn't look ok to use it for the last anchor in the message - that's why it is directly ``<a href...``